### PR TITLE
IGVF-79-add-cors-for-trusted-origins

### DIFF
--- a/config/pyramid/ini/docker.ini
+++ b/config/pyramid/ini/docker.ini
@@ -31,7 +31,8 @@ sqlalchemy.url = postgresql://postgres@postgres:5432
 testing = true
 use = egg:igvfd
 in_docker = true
-cors_trusted_origins = ['http://localhost:3000']
+cors_trusted_origins =
+    http://localhost:3000
 
 [composite:main]
 / = debug

--- a/config/pyramid/ini/docker.ini
+++ b/config/pyramid/ini/docker.ini
@@ -31,6 +31,7 @@ sqlalchemy.url = postgresql://postgres@postgres:5432
 testing = true
 use = egg:igvfd
 in_docker = true
+access_control_allowed_origins = ['http://localhost:3000']
 
 [composite:main]
 / = debug

--- a/config/pyramid/ini/docker.ini
+++ b/config/pyramid/ini/docker.ini
@@ -31,7 +31,7 @@ sqlalchemy.url = postgresql://postgres@postgres:5432
 testing = true
 use = egg:igvfd
 in_docker = true
-access_control_allowed_origins = ['http://localhost:3000']
+cors_trusted_origins = ['http://localhost:3000']
 
 [composite:main]
 / = debug

--- a/config/pyramid/ini/testing.ini
+++ b/config/pyramid/ini/testing.ini
@@ -28,6 +28,8 @@ postgresql.statement_timeout = 20
 embed_cache.capacity = 5000
 igvfd.load_test_data = igvfd.loadxl:load_test_data
 sqlalchemy.url = postgresql://postgres@postgres:5432
+cors_trusted_origins =
+    http://localhost:3000
 testing = true
 use = egg:igvfd
 in_docker = true

--- a/config/pyramid/ini/testing.ini
+++ b/config/pyramid/ini/testing.ini
@@ -28,11 +28,11 @@ postgresql.statement_timeout = 20
 embed_cache.capacity = 5000
 igvfd.load_test_data = igvfd.loadxl:load_test_data
 sqlalchemy.url = postgresql://postgres@postgres:5432
-cors_trusted_origins =
-    http://localhost:3000
 testing = true
 use = egg:igvfd
 in_docker = true
+cors_trusted_origins =
+    http://localhost:3000
 
 [composite:main]
 / = debug

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.8
 install_requires =
+    antlr4-python3-runtime==4.9.3
     PasteDeploy==2.1.1
     Pillow==7.0.0
     SQLAlchemy==1.3.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    antlr4-python3-runtime==4.9.3
     PasteDeploy==2.1.1
     Pillow==7.0.0
     SQLAlchemy==1.3.13

--- a/src/igvfd/__init__.py
+++ b/src/igvfd/__init__.py
@@ -204,6 +204,8 @@ def main(global_config, **local_config):
     # Override default authz policy set by pyramid_multiauth
     config.set_authorization_policy(LocalRolesAuthorizationPolicy())
     config.include(session)
+    # Must go before other route registration.
+    config.include('.cors')
     config.include('.auth0')
 
     config.include(configure_dbsession)

--- a/src/igvfd/auth0.py
+++ b/src/igvfd/auth0.py
@@ -43,6 +43,9 @@ def includeme(config):
     config.add_route('impersonate-user', 'impersonate-user')
 
 
+AUTH0_DOMAIN = 'dev-2bg1vkmg.us.auth0.com'
+
+
 class LoginDenied(HTTPForbidden):
     title = 'Login failure'
 
@@ -75,9 +78,8 @@ class Auth0AuthenticationPolicy(CallbackAuthenticationPolicy):
             return None
 
         try:
-            domain = 'encode.auth0.com'
             user_url = 'https://{domain}/userinfo?access_token={access_token}' \
-                .format(domain=domain, access_token=access_token)
+                .format(domain=AUTH0_DOMAIN, access_token=access_token)
             user_info = requests.get(user_url).json()
         except Exception as e:
             if self.debug:
@@ -107,11 +109,10 @@ def signup(context, request):
     Create new user.
     :param request: Pyramid request object
     """
-    domain = 'encode.auth0.com'
     access_token = request.json.get('accessToken')
     if not access_token:
         raise HTTPBadRequest(explanation='Access token required')
-    url = 'https://{domain}/userinfo?access_token={access_token}'.format(domain=domain, access_token=access_token)
+    url = 'https://{domain}/userinfo?access_token={access_token}'.format(domain=AUTH0_DOMAIN, access_token=access_token)
     user_data_request = requests.get(url)
     if user_data_request.status_code != 200:
         raise HTTPBadRequest(explanation='Could not get user data')

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -120,12 +120,26 @@ class CorsPreflightPredicate(object):
         return is_cors_preflight_request(request)
 
 
+def parse_ini_setting_as_list(ini_setting):
+    return [
+        value.strip()
+        for value in ini_setting.split('\n')
+        if value
+    ]
+
+
+def get_allowed_origins(request):
+    return parse_ini_setting_as_list(
+        request.registry.settings.get(
+            'cors_trusted_origins',
+            ''
+        )
+    )
+
+
 def origin_is_allowed(request):
     # Important for security to limit CORS to trusted origins.
-    ALLOWED_ORIGINS = request.registry.settings.get(
-        'cors_trusted_origins',
-        []
-    )
+    ALLOWED_ORIGINS = get_allowed_origins(request)
     return ALLOWED_ORIGINS and request.headers.get(ORIGIN) in ALLOWED_ORIGINS
 
 

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -123,7 +123,7 @@ class CorsPreflightPredicate(object):
 def origin_is_allowed(request):
     # Important for security to limit CORS to trusted origins.
     ALLOWED_ORIGINS = request.registry.settings.get(
-        'access_control_allowed_origins',
+        'cors_trusted_origins',
         []
     )
     return ALLOWED_ORIGINS and request.headers.get(ORIGIN) in ALLOWED_ORIGINS

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -90,7 +90,7 @@ ALLOWED_EXPOSE_HEADERS = [
     X_STATS,
 ]
 
-REQUIRED_VARY = [
+CORS_VARY = [
     ORIGIN
 ]
 
@@ -169,7 +169,7 @@ def _update_vary_header_in_response(request):
     vary = request.headers.get(VARY, [])
     request.response.headers.update(
         {
-            VARY: ','.join(vary + [ORIGIN])
+            VARY: ','.join(vary + CORS_VARY)
         }
     )
 

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -87,9 +87,9 @@ ALLOWED_EXPOSE_HEADERS = [
     X_STATS,
 ]
 
-CORS_VARY = [
-    ORIGIN
-]
+CORS_VARY = (
+    ORIGIN,
+)
 
 
 def is_cors_request(request):
@@ -177,7 +177,7 @@ def _add_allowed_preflight_cors_headers_to_response(request):
 
 
 def _update_vary_header_in_response(request):
-    vary = request.headers.get(VARY, [])
+    vary = request.response.vary or ()
     request.response.headers.update(
         {
             VARY: ','.join(vary + CORS_VARY)

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -212,7 +212,6 @@ def handle_cors_preflight(request):
     return request.response
 
 
-# View deriver
 def maybe_add_cors_to_header_view_deriver(view, info):
     def wrapper_view(context, request):
         if is_cors_request(request):

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -1,0 +1,206 @@
+from pyramid.events import NewRequest
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.view import view_config
+
+
+def includeme(config):
+    config.scan(__name__)
+    config.add_route_predicate(
+        'cors_preflight',
+        CorsPreflightPredicate
+    )
+    # Globally handle all CORS preflight OPTIONS requests.
+    config.add_route(
+        'handle-cors-preflight',
+        '{match_any:.*}',
+        cors_preflight=True,
+    )
+    config.add_subscriber(
+        maybe_add_cors_to_response_headers_subscriber,
+        NewRequest
+    )
+
+
+OPTIONS = 'OPTIONS'
+GET = 'GET'
+POST = 'POST'
+PATCH = 'PATCH'
+PUT = 'PUT'
+HEAD = 'HEAD'
+
+ACCEPT = 'Accept'
+CONTENT_TYPE = 'Content-Type'
+IF_MATCH = 'If-Match'
+ORIGIN = 'Origin'
+CACHE_CONTROL = 'Cache-Control'
+CONTENT_LANGUAGE = 'Content-Language'
+CONTENT_LENGTH = 'Content-Length'
+CONTENT_TYPE = 'Content-Type'
+EXPIRES = 'Expires'
+LAST_MODIFIED = 'Last-Modified'
+PRAGMA = 'Pragma'
+DATE = 'Date'
+TRANSFER_ENCODING = 'Transfer-Encoding'
+CONNECTION = 'Connection'
+VARY = 'Vary'
+X_REQUEST_URL = 'X-Request-Url'
+X_STATS = 'X-Stats'
+X_CSRF_TOKEN = 'X-CSRF-Token'
+X_IF_MATCH_USER = 'X-If-Match-User'
+
+ACCESS_CONTROL_REQUEST_METHOD = 'Access-Control-Request-Method'
+ACCESS_CONTROL_REQUEST_HEADERS = 'Access-Control-Request-Headers'
+
+ACCESS_CONTROL_ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+ACCESS_CONTROL_ALLOW_METHODS = 'Access-Control-Allow-Methods'
+ACCESS_CONTROL_ALLOW_HEADERS = 'Access-Control-Allow-Headers'
+ACCESS_CONTROL_EXPOSE_HEADERS = 'Access-Control-Expose-Headers'
+ACCESS_CONTROL_ALLOW_CREDENTIALS = 'Access-Control-Allow-Credentials'
+ACCESS_CONTROL_MAX_AGE = 'Access-Control-Max-Age'
+
+ALLOWED_METHODS = [
+    GET,
+    HEAD,
+    OPTIONS,
+    POST,
+    PATCH,
+    PUT,
+]
+
+ALLOWED_HEADERS = [
+    ORIGIN,
+    CONTENT_TYPE,
+    ACCEPT,
+    X_CSRF_TOKEN,
+    X_IF_MATCH_USER,
+]
+
+ALLOWED_EXPOSE_HEADERS = [
+    CACHE_CONTROL,
+    CONTENT_LANGUAGE,
+    CONTENT_LENGTH,
+    CONTENT_TYPE,
+    EXPIRES,
+    LAST_MODIFIED,
+    PRAGMA,
+    DATE,
+    TRANSFER_ENCODING,
+    CONNECTION,
+    X_REQUEST_URL,
+    X_STATS,
+]
+
+REQUIRED_VARY = [
+    ORIGIN
+]
+
+
+def is_cors_request(request):
+    return ORIGIN in request.headers
+
+
+def is_cors_preflight_request(request):
+    return (
+        request.method == OPTIONS and
+        ORIGIN in request.headers and
+        ACCESS_CONTROL_REQUEST_METHOD in request.headers and
+        ACCESS_CONTROL_REQUEST_HEADERS in request.headers
+    )
+
+
+class CorsPreflightPredicate(object):
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return f'cors_preflight: {self.val}'
+
+    phash = text
+
+    def __call__(self, context, request):
+        if not self.val:
+            return False
+        return is_cors_preflight_request(request)
+
+
+def origin_is_allowed(request):
+    # Important for security to limit CORS to trusted origins.
+    ALLOWED_ORIGINS = request.registry.settings.get(
+        'access_control_allowed_origins',
+        []
+    )
+    return ALLOWED_ORIGINS and request.headers.get(ORIGIN) in ALLOWED_ORIGINS
+
+
+def method_is_allowed(request):
+    return request.method in ALLOWED_METHODS
+
+
+def should_add_cors_to_headers(request):
+    return (
+        origin_is_allowed(request) and
+        method_is_allowed(request)
+    )
+
+
+# Dangerous to call this directly without checking
+# if Origin is allowed first.
+def _add_allowed_cors_headers_to_response(request):
+    origin = request.headers.get(ORIGIN)
+    request.response.headers.update(
+        {
+            ACCESS_CONTROL_ALLOW_ORIGIN: origin,
+            ACCESS_CONTROL_ALLOW_CREDENTIALS: 'true',
+            ACCESS_CONTROL_EXPOSE_HEADERS: ','.join(ALLOWED_EXPOSE_HEADERS),
+        }
+    )
+
+
+def _add_allowed_preflight_cors_headers_to_response(request):
+    request.response.headers.update(
+        {
+            ACCESS_CONTROL_ALLOW_METHODS: ','.join(ALLOWED_METHODS),
+            ACCESS_CONTROL_ALLOW_HEADERS: ','.join(ALLOWED_HEADERS),
+        }
+    )
+
+
+def _update_vary_header_in_response(request):
+    vary = request.headers.get(VARY, [])
+    request.response.headers.update(
+        {
+            VARY: ','.join(vary + [ORIGIN])
+        }
+    )
+
+
+def _add_cors_to_response_headers(request):
+    _add_allowed_cors_headers_to_response(request)
+    _update_vary_header_in_response(request)
+
+
+def maybe_add_cors_to_response_headers(request):
+    if should_add_cors_to_headers(request):
+        _add_cors_to_response_headers(request)
+
+
+def maybe_add_preflight_cors_to_response_headers(request):
+    if should_add_cors_to_headers(request):
+        _add_cors_to_response_headers(request)
+        _add_allowed_preflight_cors_headers_to_response(request)
+
+
+@view_config(
+    route_name='handle-cors-preflight',
+    request_method='OPTIONS',
+    permission=NO_PERMISSION_REQUIRED,
+)
+def handle_cors_preflight(request):
+    maybe_add_preflight_cors_to_response_headers(request)
+    return request.response
+
+
+def maybe_add_cors_to_response_headers_subscriber(event):
+    request = event.request
+    if is_cors_request(request):
+        maybe_add_cors_to_response_headers(request)

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -212,6 +212,7 @@ def handle_cors_preflight(request):
     return request.response
 
 
+# View deriver
 def maybe_add_cors_to_header_view_deriver(view, info):
     def wrapper_view(context, request):
         if is_cors_request(request):

--- a/src/igvfd/cors.py
+++ b/src/igvfd/cors.py
@@ -1,4 +1,5 @@
 from pyramid.events import NewRequest
+from pyramid.events import subscriber
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 
@@ -14,10 +15,6 @@ def includeme(config):
         'handle-cors-preflight',
         '{match_any:.*}',
         cors_preflight=True,
-    )
-    config.add_subscriber(
-        maybe_add_cors_to_response_headers_subscriber,
-        NewRequest
     )
 
 
@@ -200,6 +197,7 @@ def handle_cors_preflight(request):
     return request.response
 
 
+@subscriber(NewRequest)
 def maybe_add_cors_to_response_headers_subscriber(event):
     request = event.request
     if is_cors_request(request):

--- a/src/igvfd/renderers.py
+++ b/src/igvfd/renderers.py
@@ -93,6 +93,9 @@ def security_tween_factory(handler, registry):
         if request.method in ('GET', 'HEAD'):
             return handler(request)
 
+        if request.method == 'OPTIONS':
+            return handler(request)
+
         if request.content_type != 'application/json':
             detail = "%s is not 'application/json'" % request.content_type
             raise HTTPUnsupportedMediaType(detail)

--- a/src/igvfd/tests/test_cors.py
+++ b/src/igvfd/tests/test_cors.py
@@ -300,7 +300,7 @@ def test_cors_test_handle_cors_preflight_view(testapp):
     assert 'Access-Control-Allow-Headers' in response.headers
 
 
-def test_cors_maybe_add_cors_to_response_headers_subscriber(testapp):
+def test_cors_maybe_add_cors_to_header_view_deriver(testapp):
     response = testapp.get(
         '/session',
     )

--- a/src/igvfd/tests/test_cors.py
+++ b/src/igvfd/tests/test_cors.py
@@ -1,0 +1,146 @@
+import pytest
+
+
+def test_cors_is_cors_request():
+    from igvfd.cors import is_cors_request
+    from pyramid.testing import DummyRequest
+    dr = DummyRequest()
+    assert not is_cors_request(dr)
+    dr = DummyRequest(
+        headers={
+            'Origin': 'http//:localhost:3000'
+        }
+    )
+    assert is_cors_request(dr)
+
+
+def test_cors_is_cors_preflight_request():
+    from igvfd.cors import is_cors_preflight_request
+    from pyramid.testing import DummyRequest
+    dr = DummyRequest(
+        headers={
+            'Origin': 'http//:localhost:3000'
+        }
+    )
+    assert not is_cors_preflight_request(dr)
+    dr = DummyRequest(
+        method='OPTIONS',
+        headers={
+            'Origin': 'http//:localhost:3000',
+            'Access-Control-Request-Method': 'POST',
+        }
+    )
+    assert not is_cors_preflight_request(dr)
+    dr = DummyRequest(
+        method='OPTIONS',
+        headers={
+            'Origin': 'http//:localhost:3000',
+            'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'Accept,Origin,X-CSRF-Token'
+        }
+    )
+    assert is_cors_preflight_request(dr)
+
+
+def test_cors_cors_preflight_predicate():
+    from igvfd.cors import CorsPreflightPredicate
+    from pyramid.testing import DummyRequest
+    cpp = CorsPreflightPredicate(False, {})
+    assert cpp.val is False
+    cpp = CorsPreflightPredicate(True, {})
+    assert cpp.val is True
+    dr = DummyRequest(
+        headers={
+            'Origin': 'http//:localhost:3000'
+        }
+    )
+    assert cpp({}, dr) is False
+    dr = DummyRequest(
+        method='OPTIONS',
+        headers={
+            'Origin': 'http//:localhost:3000',
+            'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'Accept,Origin,X-CSRF-Token'
+        }
+    )
+    assert cpp({}, dr) is True
+
+
+def test_cors_parse_ini_setting_as_list(dummy_request):
+    from igvfd.cors import parse_ini_setting_as_list
+    assert parse_ini_setting_as_list(
+        'http://localhost:3000\nhttp://someother.com'
+    ) == [
+        'http://localhost:3000',
+        'http://someother.com'
+    ]
+    trusted_origins = dummy_request.registry.settings.get(
+        'cors_trusted_origins'
+    )
+    assert parse_ini_setting_as_list(
+        trusted_origins
+    ) == [
+        'http://localhost:3000'
+    ]
+
+
+def test_cors_get_allowed_origins(dummy_request):
+    from igvfd.cors import get_allowed_origins
+    assert get_allowed_origins(dummy_request) == [
+        'http://localhost:3000',
+    ]
+
+
+def test_cors_origin_is_allowed(dummy_request):
+    from igvfd.cors import origin_is_allowed
+    dummy_request.headers.update({'Origin': 'http://localhost:3000'})
+    assert origin_is_allowed(dummy_request)
+    dummy_request.headers.update({'Origin': 'http://localhost:2999'})
+    assert not origin_is_allowed(dummy_request)
+    original_trusted = dummy_request.registry.settings['cors_trusted_origins']
+    dummy_request.registry.settings['cors_trusted_origins'] = ''
+    assert not origin_is_allowed(dummy_request)
+    dummy_request.registry.settings['cors_trusted_origins'] = (
+        'http://localhost:2999'
+    )
+    assert origin_is_allowed(dummy_request)
+    dummy_request.registry.settings['cors_trusted_origins'] = (
+        'http://localhost:2999\nhttp://localhost:3000'
+    )
+    assert origin_is_allowed(dummy_request)
+    dummy_request.registry.settings['cors_trusted_origins'] = original_trusted
+    assert not origin_is_allowed(dummy_request)
+
+
+def test_cors_method_is_allowed(dummy_request):
+    from igvfd.cors import method_is_allowed
+    for method in [
+            'GET',
+            'POST',
+            'PATCH',
+            'PUT',
+            'OPTIONS',
+            'HEAD',
+    ]:
+        dummy_request.method = method
+        assert method_is_allowed(dummy_request)
+    for method in [
+            'DELETE',
+            'OTHER',
+    ]:
+        dummy_request.method = method
+        assert not method_is_allowed(dummy_request)
+
+
+def test_cors_should_add_cors_to_headers(dummy_request):
+    from igvfd.cors import should_add_cors_to_headers
+    assert not should_add_cors_to_headers(dummy_request)
+    dummy_request.headers.update({'Origin': 'http://localhost:2999'})
+    dummy_request.method = 'POST'
+    assert not should_add_cors_to_headers(dummy_request)
+    dummy_request.headers.update({'Origin': 'http://localhost:3000'})
+    dummy_request.method = 'POST'
+    assert should_add_cors_to_headers(dummy_request)
+    dummy_request.headers.update({'Origin': 'http://localhost:3000'})
+    dummy_request.method = 'DELETE'
+    assert not should_add_cors_to_headers(dummy_request)

--- a/src/igvfd/tests/test_cors.py
+++ b/src/igvfd/tests/test_cors.py
@@ -144,3 +144,21 @@ def test_cors_should_add_cors_to_headers(dummy_request):
     dummy_request.headers.update({'Origin': 'http://localhost:3000'})
     dummy_request.method = 'DELETE'
     assert not should_add_cors_to_headers(dummy_request)
+
+
+def test_cors_add_allowed_cors_headers_to_response(dummy_request):
+    from igvfd.cors import _add_allowed_cors_headers_to_response
+    assert 'Access-Control-Allow-Origin' not in dummy_request.response.headers
+    assert 'Access-Control-Allow-Credentials' not in dummy_request.response.headers
+    assert 'Access-Control-Expose-Headers' not in dummy_request.response.headers
+    dummy_request.headers.update(
+        {
+            'Origin': 'somehost'
+        }
+    )
+    _add_allowed_cors_headers_to_response(dummy_request)
+    print(dummy_request.response.headers)
+    assert 'Access-Control-Allow-Origin' in dummy_request.response.headers
+    assert 'Access-Control-Allow-Credentials' in dummy_request.response.headers
+    assert 'Access-Control-Expose-Headers' in dummy_request.response.headers
+    assert dummy_request.response.headers['Access-Control-Allow-Origin'] == 'somehost'

--- a/src/igvfd/tests/test_cors.py
+++ b/src/igvfd/tests/test_cors.py
@@ -261,3 +261,34 @@ def test_cors_maybe_add_preflight_cors_to_response_header(dummy_request):
     maybe_add_preflight_cors_to_response_headers(dummy_request)
     assert 'Access-Control-Allow-Methods' in dummy_request.response.headers
     assert 'Access-Control-Allow-Headers' in dummy_request.response.headers
+
+
+def test_cors_test_handle_cors_preflight_view(testapp):
+    response = testapp.options(
+        '/login',
+        status=404
+    )
+    headers = {
+        'Origin': 'http://evilhost:3000',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Accept,Origin,X-CSRF-Token,Content-Length',
+    }
+    response = testapp.options(
+        '/login',
+        headers=headers
+    )
+    assert response.status_code == 200
+    assert 'Access-Control-Allow-Methods' not in response.headers
+    assert 'Access-Control-Allow-Headers' not in response.headers
+    headers = {
+        'Origin': 'http://localhost:3000',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Accept,Origin,X-CSRF-Token,Content-Length',
+    }
+    response = testapp.options(
+        '/someotherview',
+        headers=headers
+    )
+    assert response.status_code == 200
+    assert 'Access-Control-Allow-Methods' in response.headers
+    assert 'Access-Control-Allow-Headers' in response.headers


### PR DESCRIPTION
Adding CORS support for trusted origins. Needed for [IGVF-62-auth0](https://github.com/IGVF-DACC/igvf-ui/tree/IGVF-62-auth0) to allow frontend (running on different origin) to coordinate authentication steps with Auth0 and backend, and browser to store and use authenticated session cookie.

Trusted origins can be set with `cors_trusted_origins` in Pyramid `ini` (local, test, prod would have a different trusted origin or origins). Frontend `fetch` requests must specify `credentials: "include"` if they want the browser to pass the session cookie.

The Pyramid code mainly adds two things:

1) Global `OPTIONS` view that handles all preflight requests from browser, and adds appropriate preflight CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`) to the response if the `Origin` in the request is trusted. Otherwise no headers are added. (One slight downside to this catchall `OPTIONS` view is that the request path might not actually correspond to any real views in our system. An alternative might be to automatically register a `method=OPTIONS` view for every `@view_config`, though not sure how this would work with path traversals.)
2) `View deriver` that wraps all views and adds CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, `Access-Control-Expose-Headers`) to the response if the `Origin` is trusted. Otherwise no headers are added. `Origin` is also added to the `Vary` header since `Access-Control-Allow-Origin` is set dynamically based on a given `Origin`. This is also possible using an event subscriber on `NewRequest` to modify the headers: 
```
@subscriber(NewRequest)
def cors_subscriber(event):
    request = event.request
    if is_cors_request(request):
        maybe_add_cors_to_response_headers(request)
 
```
However the benefit of the `view deriver` is that you could potentially customize/disable the CORS modification per view.

It would probably be good if @lrowe could eventually review this, especially given comments here: https://github.com/ENCODE-DCC/snovault/pull/6#commitcomment-32693845: 

> The CSRF protection should work because of cross-origin restrictions. We don't set `Access-Control-Allow-Credentials: true` so browsers will not send cookies to the server from other origins. While fetching /session from another site with XMLHttpRequest will return a new random csrf token, it will not work as cookies are disregarded so the session cookie containing the user's csrf token will not be overwritten with the new csrf token read by the attacker. Loading as a script cross-origin (which does send cookies) will not allow the attacking site to read the csrft value as it is invalid javascript (as either format=html or format=json).
> 
> I do wonder if we could simply rely on Origin header checking instead as it would simplify things client side.

I believe, given the requirement to specify a trusted origin in a CORS request, that all this remains true. It helps that browsers don't allow you to use an origin wildcard (`Access-Control-Allow-Origin: *`) if you also specify `Access-Control-Allow-Credentials: true`. It also helps that all of our unsafe methods (POST/PATCH/PUT) require specifying `Content-Type: application/json` https://github.com/IGVF-DACC/igvfd/blob/7f89120be3e76f48eb3ebc77b5039b7d9397e95a/src/igvfd/renderers.py#L96 which will trigger a preflight request in the browser (which will fail when the origin isn't trusted).

For `/session` endpoint specifically trying to make a request from untrusted origin should trigger CORS error, so even if cookie is passed it won't be set in browser. In general (and even without this change) it does look like you could hit the `/session` endpoint from an evil site with a simple GET request (e.g. `<img src="http://localhost:8000/session">`) with the cookie included. This probably isn't much to worry about (since the endpoint appears idempotent with session cookie and csrf token), but I was thinking we could require some custom header in the request to actually execute the code in the endpoint (thereby forcing browser to send preflight request before sending cookie).