### PR TITLE
IGVF-68 New properties of sample, cell_lines, and tissue schema.

### DIFF
--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -49,6 +49,9 @@
         },
         {
             "$ref": "mixins.json#/url"
+        },
+        {
+            "$ref": "mixins.json#/internal_tags"
         }
     ],
     "dependentSchemas": {
@@ -209,6 +212,13 @@
                 "description": "Ontology of the disease associated with the biosample.",
                 "type": "string"
             }
+        },
+        "nih_institutional_certification": {
+            "type": "string",
+            "title": "NIH institutional certification",
+            "description": "Institutional certification given by the NIH for human biosamples.",
+            "comment": "Required for IGVF human biosamples.",
+            "pattern": "^NIC[A-Z0-9]+$"
         },
         "date_obtained": {
             "date_obtained": {

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -51,7 +51,7 @@
             "$ref": "mixins.json#/url"
         },
         {
-            "$ref": "mixins.json#/internal_tags"
+            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -63,7 +63,7 @@
             "$ref": "mixins.json#/url"
         },
         {
-            "$ref": "mixins.json#/internal_tags"
+            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -61,6 +61,9 @@
         },
         {
             "$ref": "mixins.json#/url"
+        },
+        {
+            "$ref": "mixins.json#/internal_tags"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/changelogs/mixins.md
+++ b/src/igvfd/schemas/changelogs/mixins.md
@@ -5,3 +5,4 @@
 * 3/24/22 Added product_id, lot_id, source mixins
 * 4/5/22 Added additional_description mixin
 * 4/7/22 Added product_id, lot_id, source mixins to a set called product_info
+* 4/14/22 Added internal_tags

--- a/src/igvfd/schemas/changelogs/mixins.md
+++ b/src/igvfd/schemas/changelogs/mixins.md
@@ -5,4 +5,4 @@
 * 3/24/22 Added product_id, lot_id, source mixins
 * 4/5/22 Added additional_description mixin
 * 4/7/22 Added product_id, lot_id, source mixins to a set called product_info
-* 4/14/22 Added internal_tags
+* 4/27/22 Added collections

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -299,5 +299,26 @@
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
             "formInput": "textarea"
         }
+    },
+    "internal_tags": {
+        "internal_tags": {
+            "title": "Internal tags",
+            "description": "Some samples are part of particular data collections.",
+            "comment": "Do not submit. Internal tags are for DCC use only.",
+            "type": "array",
+            "default": [],
+            "permission": "import_items",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "Enhancers",
+                    "Repressors",
+                    "Promoters",
+                    "Variants",
+                    "ENCODE"
+                ]
+            }
+        }
     }
 }

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -300,11 +300,11 @@
             "formInput": "textarea"
         }
     },
-    "internal_tags": {
-        "internal_tags": {
-            "title": "Internal tags",
+    "collections": {
+        "collections": {
+            "title": "Collections",
             "description": "Some samples are part of particular data collections.",
-            "comment": "Do not submit. Internal tags are for DCC use only.",
+            "comment": "Do not submit. Collections are for DCC use only.",
             "type": "array",
             "default": [],
             "permission": "import_items",
@@ -312,10 +312,6 @@
             "items": {
                 "type": "string",
                 "enum": [
-                    "Enhancers",
-                    "Repressors",
-                    "Promoters",
-                    "Variants",
                     "ENCODE"
                 ]
             }

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -48,7 +48,7 @@
             "$ref": "mixins.json#/url"
         },
         {
-            "$ref": "mixins.json#/internal_tags"
+            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -46,6 +46,9 @@
         },
         {
             "$ref": "mixins.json#/url"
+        },
+        {
+            "$ref": "mixins.json#/internal_tags"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -61,7 +61,7 @@
             "$ref": "mixins.json#/url"
         },
         {
-            "$ref": "mixins.json#/internal_tags"
+            "$ref": "mixins.json#/collections"
         },
         {
             "$ref": "mixins.json#/additional_description"

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -61,6 +61,9 @@
             "$ref": "mixins.json#/url"
         },
         {
+            "$ref": "mixins.json#/internal_tags"
+        },
+        {
             "$ref": "mixins.json#/additional_description"
         }
     ],

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -63,7 +63,7 @@
             "$ref": "mixins.json#/url"
         },
         {
-            "$ref": "mixins.json#/internal_tags"
+            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -61,6 +61,9 @@
         },
         {
             "$ref": "mixins.json#/url"
+        },
+        {
+            "$ref": "mixins.json#/internal_tags"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/tests/data/inserts/cell_line.json
+++ b/src/igvfd/tests/data/inserts/cell_line.json
@@ -30,9 +30,8 @@
         "sex": "male",
         "date_obtained": "2022-02-02",
         "source": "/labs/j-michael-cherry/"
-        "internal_tags": [
-            "Enhancers",
-            "Variants"
+        "collections": [
+            "ENCODE"
         ]
     }
 ]

--- a/src/igvfd/tests/data/inserts/cell_line.json
+++ b/src/igvfd/tests/data/inserts/cell_line.json
@@ -26,8 +26,13 @@
         "life_stage": "adult",
         "biosample_ontology": "motor neuron",
         "disease_ontology": "motor neuron disease",
+        "nih_institutional_certification": "NICHD1442",
         "sex": "male",
         "date_obtained": "2022-02-02",
         "source": "/labs/j-michael-cherry/"
+        "internal_tags": [
+            "Enhancers",
+            "Variants"
+        ]
     }
 ]

--- a/src/igvfd/tests/data/inserts/cell_line.json
+++ b/src/igvfd/tests/data/inserts/cell_line.json
@@ -29,7 +29,7 @@
         "nih_institutional_certification": "NICHD1442",
         "sex": "male",
         "date_obtained": "2022-02-02",
-        "source": "/labs/j-michael-cherry/"
+        "source": "/labs/j-michael-cherry/",
         "collections": [
             "ENCODE"
         ]

--- a/src/igvfd/tests/data/inserts/technical_sample.json
+++ b/src/igvfd/tests/data/inserts/technical_sample.json
@@ -24,9 +24,8 @@
         "technical_sample_ontology": "vaccine",
         "date": "2022-04-09",
         "source": "/labs/j-michael-cherry/",
-        "internal_tags": [
-            "Enhancers",
-            "Variants"
+        "collections": [
+            "ENCODE"
         ],
         "additional_description": "The technical sample is for quality control of vaccine production."
     }

--- a/src/igvfd/tests/data/inserts/technical_sample.json
+++ b/src/igvfd/tests/data/inserts/technical_sample.json
@@ -24,6 +24,10 @@
         "technical_sample_ontology": "vaccine",
         "date": "2022-04-09",
         "source": "/labs/j-michael-cherry/",
+        "internal_tags": [
+            "Enhancers",
+            "Variants"
+        ],
         "additional_description": "The technical sample is for quality control of vaccine production."
     }
 ]

--- a/src/igvfd/tests/data/inserts/tissue.json
+++ b/src/igvfd/tests/data/inserts/tissue.json
@@ -9,8 +9,13 @@
         "status": "in progress",
         "organism": "Homo sapiens",
         "source": "/labs/j-michael-cherry/",
+        "nih_institutional_certification": "NICHD1442",
         "PMI": 2,
         "PMI_units": "week",
-        "preservation_method": "cryopreservation"
+        "preservation_method": "cryopreservation",
+        "internal_tags": [
+            "Enhancers",
+            "Variants"
+        ]
     }
 ]

--- a/src/igvfd/tests/data/inserts/tissue.json
+++ b/src/igvfd/tests/data/inserts/tissue.json
@@ -13,9 +13,8 @@
         "PMI": 2,
         "PMI_units": "week",
         "preservation_method": "cryopreservation",
-        "internal_tags": [
-            "Enhancers",
-            "Variants"
+        "collections": [
+            "ENCODE"
         ]
     }
 ]

--- a/src/igvfd/tests/test_schema_cell_line.py
+++ b/src/igvfd/tests/test_schema_cell_line.py
@@ -41,3 +41,25 @@ def test_lifestage_dependency(cell_line, testapp):
         cell_line['@id'],
         {'organism': 'Saccharomyces', 'life_stage': 'adult'}, expect_errors=True)
     assert(res.status_code == 422)
+
+
+def test_nih_institutional_certification(cell_line, testapp):
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'nih_institutional_certification': 'NICHD1455'})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'nih_institutional_certification': 'ABBBCCCHD1455'}, expect_errors=True)
+    assert(res.status_code == 422)
+
+
+def test_interal_tags(cell_line, testapp):
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'internal_tags': ['Enhancers']})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+    assert(res.status_code == 422)

--- a/src/igvfd/tests/test_schema_cell_line.py
+++ b/src/igvfd/tests/test_schema_cell_line.py
@@ -54,12 +54,12 @@ def test_nih_institutional_certification(cell_line, testapp):
     assert(res.status_code == 422)
 
 
-def test_interal_tags(cell_line, testapp):
+def test_collections(cell_line, testapp):
     res = testapp.patch_json(
         cell_line['@id'],
-        {'internal_tags': ['Enhancers']})
+        {'collections': ['ENCODE']})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         cell_line['@id'],
-        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+        {'collections': ['ABBBCCCHD1455']}, expect_errors=True)
     assert(res.status_code == 422)

--- a/src/igvfd/tests/test_schema_technical_sample.py
+++ b/src/igvfd/tests/test_schema_technical_sample.py
@@ -23,3 +23,14 @@ def test_technical_sample_type_dependency(technical_sample_1, testapp):
         {'sample_material': 'not a real type'}, expect_errors=True)
     print('status code: ' + str(res.status_code))
     assert(res.status_code == 422)
+
+
+def test_interal_tags(technical_sample_1, testapp):
+    res = testapp.patch_json(
+        technical_sample_1['@id'],
+        {'internal_tags': ['Enhancers']})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        technical_sample_1['@id'],
+        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+    assert(res.status_code == 422)

--- a/src/igvfd/tests/test_schema_technical_sample.py
+++ b/src/igvfd/tests/test_schema_technical_sample.py
@@ -25,12 +25,12 @@ def test_technical_sample_type_dependency(technical_sample_1, testapp):
     assert(res.status_code == 422)
 
 
-def test_interal_tags(technical_sample_1, testapp):
+def test_collections(technical_sample_1, testapp):
     res = testapp.patch_json(
         technical_sample_1['@id'],
-        {'internal_tags': ['Enhancers']})
+        {'collections': ['ENCODE']})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         technical_sample_1['@id'],
-        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+        {'collections': ['ABBBCCCHD1455']}, expect_errors=True)
     assert(res.status_code == 422)

--- a/src/igvfd/tests/test_schema_tissue.py
+++ b/src/igvfd/tests/test_schema_tissue.py
@@ -41,3 +41,25 @@ def test_lifestage_dependency(tissue, testapp):
         tissue['@id'],
         {'organism': 'Saccharomyces', 'life_stage': 'child'}, expect_errors=True)
     assert(res.status_code == 422)
+
+
+def test_nih_institutional_certification(tissue, testapp):
+    res = testapp.patch_json(
+        tissue['@id'],
+        {'nih_institutional_certification': 'NICHD1455'})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        tissue['@id'],
+        {'nih_institutional_certification': 'ABBBCCCHD1455'}, expect_errors=True)
+    assert(res.status_code == 422)
+
+
+def test_interal_tags(tissue, testapp):
+    res = testapp.patch_json(
+        tissue['@id'],
+        {'internal_tags': ['Enhancers']})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        tissue['@id'],
+        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+    assert(res.status_code == 422)

--- a/src/igvfd/tests/test_schema_tissue.py
+++ b/src/igvfd/tests/test_schema_tissue.py
@@ -54,12 +54,12 @@ def test_nih_institutional_certification(tissue, testapp):
     assert(res.status_code == 422)
 
 
-def test_interal_tags(tissue, testapp):
+def test_collections(tissue, testapp):
     res = testapp.patch_json(
         tissue['@id'],
-        {'internal_tags': ['Enhancers']})
+        {'collections': ['ENCODE']})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         tissue['@id'],
-        {'internal_tags': ['ABBBCCCHD1455']}, expect_errors=True)
+        {'collections': ['ABBBCCCHD1455']}, expect_errors=True)
     assert(res.status_code == 422)


### PR DESCRIPTION
Initial implementation of new properties of sample, cell_lines, and tissue schema.

- nih_institutional_certification (added at the level of biosample use encodeD as a model) abstract class.  This is inherited by tissue and cell_lines classes.
- internal_tags (added in the mixins and then on the level of sample, use encodeD as a model but limit the tags).  This is inherited by tissue, cell_lines, and technical_sample classes.
- Added unit test for the new properties.

