### PR TITLE
IGVF-126-biosample-age-string

### DIFF
--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -167,8 +167,7 @@
         "age": {
             "title": "Age",
             "description": "Age of organism at collection of the biosample.",
-            "type": "number",
-            "minimum": 0
+            "type": "string"
         },
         "age_units": {
             "title": "Age units",

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -167,7 +167,9 @@
         "age": {
             "title": "Age",
             "description": "Age of organism at collection of the biosample.",
-            "type": "string"
+            "comment": "",
+            "type": "string",
+            "pattern": "^((\\d+(\\.[1-9])?(\\-\\d+(\\.[1-9])?)?)|(unknown))$"
         },
         "age_units": {
             "title": "Age units",

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -105,7 +105,7 @@
             ]
         },
         "age_units": {
-            "comment": "Age units is required if age is specified as anything but unknown. Human biosamples cannot have age units of minutes or hours. Yeast biosamples cannot have age units of years or months.",
+            "comment": "Human biosamples cannot have age units of minutes or hours. Yeast biosamples cannot have age units of years or months.",
             "required": [
                 "age"
             ],

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -58,8 +58,57 @@
         "$merge": [
             "sample.json#/dependentSchemas"
         ],
+        "age": {
+            "comment": "Biosample with a defined age requires age_units.",
+            "allOf": [
+                {
+                    "if": {
+                        "not": {
+                            "properties": {
+                                "age": {
+                                    "const": "unknown"
+                                }
+                            }
+                        },
+                        "required": [
+                            "age"
+                        ]
+                    },
+                    "then": {
+                        "required": [
+                            "age_units"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "age_units": {
+                                "const": "year"
+                            },
+                            "organism": {
+                                "const": "Homo sapiens"
+                            }
+                        },
+                        "required": [
+                            "organism"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "age": {
+                                "pattern": "^(([1-8]?\\d)|(90 or above))$"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "age_units": {
-            "comment": "Human biosamples cannot have age units of minutes or hours. Yeast biosamples cannot have age units of years or months.",
+            "comment": "Age units is required if age is specified as anything but unknown. Human biosamples cannot have age units of minutes or hours. Yeast biosamples cannot have age units of years or months.",
+            "required": [
+                "age"
+            ],
             "allOf": [
                 {
                     "not": {
@@ -167,9 +216,9 @@
         "age": {
             "title": "Age",
             "description": "Age of organism at collection of the biosample.",
-            "comment": "",
+            "comment": "Ages over 90 years are generic for privacy purposes.",
             "type": "string",
-            "pattern": "^((\\d+(\\.[1-9])?(\\-\\d+(\\.[1-9])?)?)|(unknown))$"
+            "pattern": "^((\\d+(\\.[1-9])?(\\-\\d+(\\.[1-9])?)?)|(unknown)|([1-8]?\\d)|(90 or above))$"
         },
         "age_units": {
             "title": "Age units",

--- a/src/igvfd/tests/data/inserts/cell_line.json
+++ b/src/igvfd/tests/data/inserts/cell_line.json
@@ -21,7 +21,7 @@
             "GEO:SAMN1"
         ],
         "organism": "Homo sapiens",
-        "age": 40,
+        "age": "40",
         "age_units": "year",
         "life_stage": "adult",
         "biosample_ontology": "motor neuron",
@@ -50,7 +50,7 @@
         "starting_amount": 5,
         "starting_amount_units": "μg",
         "organism": "Homo sapiens",
-        "age": 30,
+        "age": "30",
         "age_units": "year",
         "life_stage": "adult",
         "biosample_ontology": "motor neuron",

--- a/src/igvfd/tests/data/inserts/differentiated_cell.json
+++ b/src/igvfd/tests/data/inserts/differentiated_cell.json
@@ -14,6 +14,8 @@
         "treatments": [
             "3280b708-0f05-40fa-bff2-54e2b6505c13",
             "10c05ac0-52a2-11e6-bdf4-0800200c9a66"
-        ]
+        ],
+        "age": "90 or above",
+        "age_units": "year"
     }
 ]

--- a/src/igvfd/tests/data/inserts/differentiated_tissue.json
+++ b/src/igvfd/tests/data/inserts/differentiated_tissue.json
@@ -13,6 +13,8 @@
         "post_differentiation_time_units": "day",
         "treatments": [
             "4fbb0dc2-c72e-11ec-9d64-0242ac120002"
-        ]
+        ],
+        "age": "89",
+        "age_units": "year"
     }
 ]

--- a/src/igvfd/tests/data/inserts/primary_cell.json
+++ b/src/igvfd/tests/data/inserts/primary_cell.json
@@ -21,7 +21,7 @@
             "GEO:SAMN45"
         ],
         "organism": "Homo sapiens",
-        "age": 40,
+        "age": "40",
         "age_units": "year",
         "life_stage": "adult",
         "biosample_ontology": "motor neuron",
@@ -50,7 +50,7 @@
         "starting_amount": 15,
         "starting_amount_units": "μg",
         "organism": "Homo sapiens",
-        "age": 30,
+        "age": "30",
         "age_units": "year",
         "life_stage": "adult",
         "biosample_ontology": "motor neuron",

--- a/src/igvfd/tests/data/inserts/tissue.json
+++ b/src/igvfd/tests/data/inserts/tissue.json
@@ -15,7 +15,9 @@
         "preservation_method": "cryopreservation",
         "collections": [
             "ENCODE"
-        ]
+        ],
+        "age": "30",
+        "age_units": "month"
     },
     {
         "uuid": "984a5f8e-c751-11ec-9d64-0242ac120002",
@@ -34,6 +36,8 @@
         "donors": [
             "c37934b0-4269-4470-be53-9eac7b196447",
             "05c0a52c-f861-4057-b3eb-751624bdff37"
-        ]
+        ],
+        "age": "30",
+        "age_units": "week"
     }
 ]

--- a/src/igvfd/tests/test_schema_cell_line.py
+++ b/src/igvfd/tests/test_schema_cell_line.py
@@ -13,10 +13,37 @@ def test_lot_id_dependency(cell_line, testapp):
     assert(res.status_code == 422)
 
 
+def test_age_regex(cell_line, testapp):
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'organism': 'Homo sapiens', 'age': '50', 'age_units': 'month'})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'age': '100'})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'age_units': 'year'}, expect_errors=True)
+    assert(res.status_code == 422)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'age': '90 or above'})
+    assert(res.status_code == 200)
+
+
 def test_age_unit_dependency(cell_line, testapp):
     res = testapp.patch_json(
         cell_line['@id'],
-        {'organism': 'Homo sapiens', 'age_units': 'year'})
+        {'organism': 'Homo sapiens', 'age': '5'}, expect_errors=True)
+    assert(res.status_code == 422)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'age': 'unknown'})
+    assert(res.status_code == 200)
+    res = testapp.patch_json(
+        cell_line['@id'],
+        {'organism': 'Homo sapiens', 'age_units': 'year', 'age': '5'})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         cell_line['@id'],

--- a/src/igvfd/tests/test_schema_differentiated_tissue.py
+++ b/src/igvfd/tests/test_schema_differentiated_tissue.py
@@ -27,7 +27,7 @@ def test_post_differentiated_tissue(testapp, award, lab, source, treatment_1):
 def test_differentiated_tissue_age_unit_dependency(differentiated_tissue, testapp):
     res = testapp.patch_json(
         differentiated_tissue['@id'],
-        {'organism': 'Saccharomyces', 'age_units': 'minute'})
+        {'organism': 'Saccharomyces', 'age': '5', 'age_units': 'minute'})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         differentiated_tissue['@id'],

--- a/src/igvfd/tests/test_schema_primary_cell.py
+++ b/src/igvfd/tests/test_schema_primary_cell.py
@@ -16,7 +16,7 @@ def test_lot_id_dependency(primary_cell, testapp):
 def test_age_unit_dependency(primary_cell, testapp):
     res = testapp.patch_json(
         primary_cell['@id'],
-        {'organism': 'Homo sapiens', 'age_units': 'year'})
+        {'organism': 'Homo sapiens', 'age': '5', 'age_units': 'year'})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         primary_cell['@id'],

--- a/src/igvfd/tests/test_schema_tissue.py
+++ b/src/igvfd/tests/test_schema_tissue.py
@@ -16,7 +16,7 @@ def test_lot_id_dependency(tissue, testapp):
 def test_age_unit_dependency(tissue, testapp):
     res = testapp.patch_json(
         tissue['@id'],
-        {'organism': 'Saccharomyces', 'age_units': 'minute'})
+        {'organism': 'Saccharomyces', 'age': '5', 'age_units': 'minute'})
     assert(res.status_code == 200)
     res = testapp.patch_json(
         tissue['@id'],


### PR DESCRIPTION
Encode has [dependencies](https://github.com/ENCODE-DCC/encoded/blob/428818fced4c5ca049680cf5143966ab46dd987d/src/encoded/schemas/human_donor.json#L46) for age and life_stage and a pattern for [age](https://github.com/ENCODE-DCC/encoded/blob/428818fced4c5ca049680cf5143966ab46dd987d/src/encoded/schemas/human_donor.json#L120) let me know if I should implement these. @cricketsloan 