### PR TITLE
IGVF-134 Update Auth0 tenant domain

### DIFF
--- a/src/igvfd/auth0.py
+++ b/src/igvfd/auth0.py
@@ -43,7 +43,7 @@ def includeme(config):
     config.add_route('impersonate-user', 'impersonate-user')
 
 
-AUTH0_DOMAIN = 'dev-2bg1vkmg.us.auth0.com'
+AUTH0_DOMAIN = 'igvf-dacc.us.auth0.com'
 
 
 class LoginDenied(HTTPForbidden):


### PR DESCRIPTION
We have a new Auth0 tenant at igvf-dacc.us.auth0.com. This branch updates this from the old tenant (dev-2bg1vkmg.us.auth0.com).

To sign in, you also need updated environment variable files from:
https://drive.google.com/drive/folders/1jBPTau0Bqzr418IjraWnEhFgiy09e_98?usp=sharing

Copy these files into your igvf-ui root directory, renaming `dot-env.local` to `.env.local`.