### PR TITLE
IGVF-147 mixins

### DIFF
--- a/src/igvfd/schemas/access_key.json
+++ b/src/igvfd/schemas/access_key.json
@@ -6,9 +6,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         }
     ],

--- a/src/igvfd/schemas/access_key.json
+++ b/src/igvfd/schemas/access_key.json
@@ -9,7 +9,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         }
     ],
     "type": "object",

--- a/src/igvfd/schemas/assay_ontology_term.json
+++ b/src/igvfd/schemas/assay_ontology_term.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/aliases"

--- a/src/igvfd/schemas/assay_ontology_term.json
+++ b/src/igvfd/schemas/assay_ontology_term.json
@@ -15,7 +15,7 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
+            "$ref": "ontology_term.json#/properties"
         },
         {
             "$ref": "mixins.json#/basic_item"
@@ -25,9 +25,6 @@
         },
         {
             "$ref": "mixins.json#/standard_status"
-        },
-        {
-            "$ref": "ontology_term.json#/properties"
         }
     ],
     "properties": {

--- a/src/igvfd/schemas/assay_ontology_term.json
+++ b/src/igvfd/schemas/assay_ontology_term.json
@@ -27,9 +27,6 @@
             "$ref": "mixins.json#/standard_status"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "ontology_term.json#/properties"
         }
     ],

--- a/src/igvfd/schemas/award.json
+++ b/src/igvfd/schemas/award.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/award.json
+++ b/src/igvfd/schemas/award.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/url"

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -21,9 +21,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -18,9 +18,6 @@
             "$ref": "mixins.json#/basic_item"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/accession"
         },
         {
@@ -40,9 +37,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -15,6 +15,9 @@
             "$ref": "sample.json#/properties"
         },
         {
+            "$ref": "mixins.json#/basic_item"
+        },
+        {
             "$ref": "mixins.json#/schema_version"
         },
         {

--- a/src/igvfd/schemas/biosample.json
+++ b/src/igvfd/schemas/biosample.json
@@ -24,9 +24,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -34,9 +31,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -45,9 +45,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -24,9 +24,6 @@
             "$ref": "biosample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -49,9 +46,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -43,9 +40,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -27,7 +27,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/cell_line.json
+++ b/src/igvfd/schemas/cell_line.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/differentiated_cell.json
+++ b/src/igvfd/schemas/differentiated_cell.json
@@ -45,9 +45,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/differentiated_cell.json
+++ b/src/igvfd/schemas/differentiated_cell.json
@@ -24,9 +24,6 @@
             "$ref": "biosample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/differentiated_cell.json
+++ b/src/igvfd/schemas/differentiated_cell.json
@@ -27,7 +27,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/differentiated_cell.json
+++ b/src/igvfd/schemas/differentiated_cell.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -43,12 +40,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
-        },
-        {
-            "$ref": "mixins.json#/documents"
         },
         {
             "$ref": "mixins.json#/product_info"

--- a/src/igvfd/schemas/differentiated_cell.json
+++ b/src/igvfd/schemas/differentiated_cell.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/differentiated_tissue.json
+++ b/src/igvfd/schemas/differentiated_tissue.json
@@ -45,9 +45,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/differentiated_tissue.json
+++ b/src/igvfd/schemas/differentiated_tissue.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -43,9 +40,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/differentiated_tissue.json
+++ b/src/igvfd/schemas/differentiated_tissue.json
@@ -24,9 +24,6 @@
             "$ref": "biosample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/differentiated_tissue.json
+++ b/src/igvfd/schemas/differentiated_tissue.json
@@ -27,7 +27,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/differentiated_tissue.json
+++ b/src/igvfd/schemas/differentiated_tissue.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/disease_ontology_term.json
+++ b/src/igvfd/schemas/disease_ontology_term.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/aliases"

--- a/src/igvfd/schemas/disease_ontology_term.json
+++ b/src/igvfd/schemas/disease_ontology_term.json
@@ -25,7 +25,7 @@
         },
         {
             "$ref": "mixins.json#/standard_status"
-        } 
+        }
     ],
     "properties": {
         "schema_version": {

--- a/src/igvfd/schemas/disease_ontology_term.json
+++ b/src/igvfd/schemas/disease_ontology_term.json
@@ -27,9 +27,6 @@
             "$ref": "mixins.json#/standard_status"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "ontology_term.json#/properties"
         }
     ],

--- a/src/igvfd/schemas/disease_ontology_term.json
+++ b/src/igvfd/schemas/disease_ontology_term.json
@@ -15,7 +15,7 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
+            "$ref": "ontology_term.json#/properties"
         },
         {
             "$ref": "mixins.json#/basic_item"
@@ -25,10 +25,7 @@
         },
         {
             "$ref": "mixins.json#/standard_status"
-        },
-        {
-            "$ref": "ontology_term.json#/properties"
-        }
+        } 
     ],
     "properties": {
         "schema_version": {

--- a/src/igvfd/schemas/document.json
+++ b/src/igvfd/schemas/document.json
@@ -21,7 +21,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/attachment"

--- a/src/igvfd/schemas/document.json
+++ b/src/igvfd/schemas/document.json
@@ -37,9 +37,6 @@
         },
         {
             "$ref": "mixins.json#/submitted"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/document.json
+++ b/src/igvfd/schemas/document.json
@@ -18,9 +18,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/donor.json
+++ b/src/igvfd/schemas/donor.json
@@ -21,9 +21,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/donor.json
+++ b/src/igvfd/schemas/donor.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/donor.json
+++ b/src/igvfd/schemas/donor.json
@@ -15,7 +15,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/donor.json
+++ b/src/igvfd/schemas/donor.json
@@ -21,9 +21,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -31,9 +28,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/donor.json
+++ b/src/igvfd/schemas/donor.json
@@ -12,9 +12,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -37,9 +34,6 @@
         },
         {
             "$ref": "mixins.json#/references"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "properties": {

--- a/src/igvfd/schemas/gene.json
+++ b/src/igvfd/schemas/gene.json
@@ -24,9 +24,6 @@
             "$ref": "mixins.json#/basic_item"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "mixins.json#/standard_status"
         }
     ],

--- a/src/igvfd/schemas/gene.json
+++ b/src/igvfd/schemas/gene.json
@@ -21,7 +21,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/notes"

--- a/src/igvfd/schemas/gene.json
+++ b/src/igvfd/schemas/gene.json
@@ -18,9 +18,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/human_donor.json
+++ b/src/igvfd/schemas/human_donor.json
@@ -24,7 +24,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/human_donor.json
+++ b/src/igvfd/schemas/human_donor.json
@@ -42,9 +42,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/human_donor.json
+++ b/src/igvfd/schemas/human_donor.json
@@ -30,9 +30,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -40,9 +37,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/human_donor.json
+++ b/src/igvfd/schemas/human_donor.json
@@ -21,9 +21,6 @@
             "$ref": "donor.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -46,9 +43,6 @@
         },
         {
             "$ref": "mixins.json#/references"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "properties": {

--- a/src/igvfd/schemas/human_donor.json
+++ b/src/igvfd/schemas/human_donor.json
@@ -30,9 +30,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/image.json
+++ b/src/igvfd/schemas/image.json
@@ -16,7 +16,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/attachment"

--- a/src/igvfd/schemas/image.json
+++ b/src/igvfd/schemas/image.json
@@ -13,9 +13,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/image.json
+++ b/src/igvfd/schemas/image.json
@@ -25,9 +25,6 @@
             "$ref": "mixins.json#/submitted"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "mixins.json#/standard_status"
         }
     ],

--- a/src/igvfd/schemas/lab.json
+++ b/src/igvfd/schemas/lab.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/lab.json
+++ b/src/igvfd/schemas/lab.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/url"

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -31,9 +31,7 @@
             "format": "accession",
             "serverDefault": "accession",
             "permission": "import_items"
-        }
-    },
-    "alternate_accessions": {
+        },
         "alternate_accessions": {
             "title": "Alternate accessions",
             "description": "Accessions previously assigned to objects that have been merged with this object.",
@@ -228,16 +226,6 @@
             "description": "Additional information specified by the submitter to be displayed as a comment on the portal.",
             "type": "string",
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
-            "formInput": "textarea"
-        }
-    },
-    "reviewer_comment": {
-        "reviewer_comment": {
-            "title": "Reviewer comment",
-            "description": "Comments from the reviewer to justify the assigned review status of a characterization.",
-            "type": "string",
-            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
-            "permission": "import_items",
             "formInput": "textarea"
         }
     },

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -277,15 +277,6 @@
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$"
         }
     },
-    "additional_description": {
-        "additional_description": {
-            "title": "Additional Description",
-            "description": "Additional description of entry.",
-            "type": "string",
-            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
-            "formInput": "textarea"
-        }
-    },
     "collections": {
         "collections": {
             "title": "Collections",

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -1,6 +1,6 @@
 {
     "title": "Mixin properties",
-    "schema_version": {
+    "basic_item": {
         "schema_version": {
             "title": "Schema version",
             "description": "The version of the JSON schema that the server uses to validate the object.",
@@ -8,9 +8,7 @@
             "type": "string",
             "pattern": "^\\d+(\\.\\d+)*$",
             "requestMethod": []
-        }
-    },
-    "basic_item": {
+        },
         "uuid": {
             "title": "UUID",
             "description": "The unique identifier associated with every object.",
@@ -54,6 +52,21 @@
                 "comment": "Only accessions of objects that have status equal replaced will work here.",
                 "type": "string",
                 "format": "accession"
+            }
+        },
+        "collections": {
+            "title": "Collections",
+            "description": "Some samples are part of particular data collections.",
+            "comment": "Do not submit. Collections are for DACC use only.",
+            "type": "array",
+            "default": [],
+            "permission": "import_items",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": [
+                    "ENCODE"
+                ]
             }
         },
         "status": {
@@ -271,23 +284,6 @@
             "description": "The product identifier provided by the originating lab or vendor.",
             "type": "string",
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$"
-        }
-    },
-    "collections": {
-        "collections": {
-            "title": "Collections",
-            "description": "Some samples are part of particular data collections.",
-            "comment": "Do not submit. Collections are for DCC use only.",
-            "type": "array",
-            "default": [],
-            "permission": "import_items",
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "enum": [
-                    "ENCODE"
-                ]
-            }
         }
     },
     "references": {

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -134,6 +134,13 @@
             "linkTo": "User",
             "serverDefault": "userid",
             "permission": "import_items"
+        },
+        "submitter_comment": {
+            "title": "Submitter comment",
+            "description": "Additional information specified by the submitter to be displayed as a comment on the portal.",
+            "type": "string",
+            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
+            "formInput": "textarea"
         }
     },
     "attribution": {
@@ -217,15 +224,6 @@
             "type": "string",
             "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
             "permission": "import_items",
-            "formInput": "textarea"
-        }
-    },
-    "submitter_comment": {
-        "submitter_comment": {
-            "title": "Submitter comment",
-            "description": "Additional information specified by the submitter to be displayed as a comment on the portal.",
-            "type": "string",
-            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
             "formInput": "textarea"
         }
     },

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -20,6 +20,15 @@
             "serverDefault": "uuid4",
             "permission": "import_items",
             "requestMethod": "POST"
+        },
+        "notes": {
+            "title": "Notes",
+            "description": "DACC internal notes.",
+            "comment": "Do not submit. A place for the DACC to keep information that does not have a place in the schema.",
+            "type": "string",
+            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
+            "permission": "import_items",
+            "formInput": "textarea"
         }
     },
     "accession": {
@@ -46,6 +55,21 @@
                 "type": "string",
                 "format": "accession"
             }
+        },
+        "status": {
+            "title": "Status",
+            "type": "string",
+            "permission": "import_items",
+            "default": "in progress",
+            "description": "The status of the metadata object.",
+            "comment": "Do not submit.  This is set by admins along the process of metadata submission.",
+            "enum": [
+                "in progress",
+                "released",
+                "deleted",
+                "replaced",
+                "revoked"
+            ]
         }
     },
     "aliases": {
@@ -64,23 +88,6 @@
                 "type": "string",
                 "pattern": "^(?:j-michael-cherry|ali-mortazavi|barbara-wold|lior-pachter|grant-macgregor|kim-green|mark-craven|qiongshi-lu|audrey-gasch|robert-steiner|jesse-engreitz|thomas-quertermous|anshul-kundaje|michael-bassik|will-greenleaf|marlene-rabinovitch|lars-steinmetz|jay-shendure|nadav-ahituv|martin-kircher|danwei-huangfu|michael-beer|anna-katerina-hadjantonakis|christina-leslie|alexander-rudensky|laura-donlin|hannah-carter|bing-ren|kyle-gaulton|maike-sander|charles-gersbach|gregory-crawford|tim-reddy|ansuman-sapathy|andrew-allen|gary-hon|nikhil-munshi|w-lee-kraus|lea-starita|doug-fowler|luca-pinello|guillaume-lettre|benhur-lee|daniel-bauer|richard-sherwood|benjamin-kleinstiver|marc-vidal|david-hill|frederick-roth|mikko-taipale|anne-carpenter|hyejung-won|karen-mohlke|michael-love|jason-buenrostro|bradley-bernstein|hilary-finucane|chongyuan-luo|noah-zaitlen|kathrin-plath|roy-wollman|jason-ernst|zhiping-weng|manuel-garber|xihong-lin|alan-boyle|ryan-mills|jie-liu|maureen-sartor|joshua-welch|stephen-montgomery|alexis-battle|livnat-jerby|jonathan-pritchard|predrag-radivojac|sean-mooney|harinder-singh|nidhi-sahni|jishnu-das|igvf|igvf-dacc):[a-zA-Z\\d_$.+!*,()'-]+(?:\\s[a-zA-Z\\d_$.+!*,()'-]+)*$"
             }
-        }
-    },
-    "accessioned_status": {
-        "status": {
-            "title": "Status",
-            "type": "string",
-            "permission": "import_items",
-            "default": "in progress",
-            "description": "The status of the metadata object.",
-            "comment": "Do not submit.  This is set by admins along the process of metadata submission.",
-            "enum": [
-                "in progress",
-                "released",
-                "deleted",
-                "replaced",
-                "revoked"
-            ]
         }
     },
     "standard_status": {
@@ -214,17 +221,6 @@
                     "minimum": 0
                 }
             }
-        }
-    },
-    "notes": {
-        "notes": {
-            "title": "Notes",
-            "description": "DCC internal notes.",
-            "comment": "Do not submit. A place for the DCC to keep information that does not have a place in the schema.",
-            "type": "string",
-            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
-            "permission": "import_items",
-            "formInput": "textarea"
         }
     },
     "url": {

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -10,7 +10,7 @@
             "requestMethod": []
         }
     },
-    "uuid": {
+    "basic_item": {
         "uuid": {
             "title": "UUID",
             "description": "The unique identifier associated with every object.",

--- a/src/igvfd/schemas/ontology_term.json
+++ b/src/igvfd/schemas/ontology_term.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/aliases"

--- a/src/igvfd/schemas/ontology_term.json
+++ b/src/igvfd/schemas/ontology_term.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/ontology_term.json
+++ b/src/igvfd/schemas/ontology_term.json
@@ -25,9 +25,6 @@
         },
         {
             "$ref": "mixins.json#/standard_status"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         }
     ],
     "properties": {

--- a/src/igvfd/schemas/page.json
+++ b/src/igvfd/schemas/page.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/standard_status"

--- a/src/igvfd/schemas/page.json
+++ b/src/igvfd/schemas/page.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/primary_cell.json
+++ b/src/igvfd/schemas/primary_cell.json
@@ -45,9 +45,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/primary_cell.json
+++ b/src/igvfd/schemas/primary_cell.json
@@ -24,9 +24,6 @@
             "$ref": "biosample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -49,9 +46,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/primary_cell.json
+++ b/src/igvfd/schemas/primary_cell.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -43,9 +40,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/primary_cell.json
+++ b/src/igvfd/schemas/primary_cell.json
@@ -27,7 +27,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/primary_cell.json
+++ b/src/igvfd/schemas/primary_cell.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/rodent_donor.json
+++ b/src/igvfd/schemas/rodent_donor.json
@@ -32,9 +32,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/rodent_donor.json
+++ b/src/igvfd/schemas/rodent_donor.json
@@ -23,9 +23,6 @@
             "$ref": "donor.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -51,9 +48,6 @@
         },
         {
             "$ref": "mixins.json#/references"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/rodent_donor.json
+++ b/src/igvfd/schemas/rodent_donor.json
@@ -26,7 +26,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/rodent_donor.json
+++ b/src/igvfd/schemas/rodent_donor.json
@@ -32,9 +32,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -42,9 +39,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/rodent_donor.json
+++ b/src/igvfd/schemas/rodent_donor.json
@@ -44,9 +44,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -18,9 +18,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -30,9 +30,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -15,6 +15,9 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
+            "$ref": "mixins.json#/basic_item"
+        },
+        {
             "$ref": "mixins.json#/accession"
         },
         {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -12,9 +12,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -37,9 +34,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/sample.json
+++ b/src/igvfd/schemas/sample.json
@@ -21,9 +21,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -31,9 +28,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/sample_ontology_term.json
+++ b/src/igvfd/schemas/sample_ontology_term.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/aliases"

--- a/src/igvfd/schemas/sample_ontology_term.json
+++ b/src/igvfd/schemas/sample_ontology_term.json
@@ -15,7 +15,7 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
+            "$ref": "ontology_term.json#/properties"
         },
         {
             "$ref": "mixins.json#/basic_item"
@@ -25,9 +25,6 @@
         },
         {
             "$ref": "mixins.json#/standard_status"
-        },
-        {
-            "$ref": "ontology_term.json#/properties"
         }
     ],
     "properties": {

--- a/src/igvfd/schemas/sample_ontology_term.json
+++ b/src/igvfd/schemas/sample_ontology_term.json
@@ -27,9 +27,6 @@
             "$ref": "mixins.json#/standard_status"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "ontology_term.json#/properties"
         }
     ],

--- a/src/igvfd/schemas/source.json
+++ b/src/igvfd/schemas/source.json
@@ -27,9 +27,6 @@
             "$ref": "mixins.json#/standard_status"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         }
     ],

--- a/src/igvfd/schemas/source.json
+++ b/src/igvfd/schemas/source.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/source.json
+++ b/src/igvfd/schemas/source.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/url"

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -31,9 +31,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -56,9 +56,6 @@
         },
         {
             "$ref": "mixins.json#/collections"
-        },
-        {
-            "$ref": "mixins.json#/additional_description"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -22,9 +22,6 @@
             "$ref": "sample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -47,9 +44,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -43,9 +43,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -92,6 +92,13 @@
             "title": "Technical sample ontology",
             "description": "Ontology of the technical sample.",
             "type": "string"
+        },
+        "additional_description": {
+            "title": "Additional Description",
+            "description": "Additional description of entry.",
+            "type": "string",
+            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$",
+            "formInput": "textarea"
         }
     },
     "changelog": "/profiles/changelogs/technical_sample.md"

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -25,7 +25,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/technical_sample.json
+++ b/src/igvfd/schemas/technical_sample.json
@@ -31,9 +31,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -41,9 +38,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -45,9 +45,6 @@
             "$ref": "mixins.json#/attribution"
         },
         {
-            "$ref": "mixins.json#/submitter_comment"
-        },
-        {
             "$ref": "mixins.json#/notes"
         },
         {

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -24,9 +24,6 @@
             "$ref": "biosample.json#/properties"
         },
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {
@@ -49,9 +46,6 @@
         },
         {
             "$ref": "mixins.json#/url"
-        },
-        {
-            "$ref": "mixins.json#/collections"
         }
     ],
     "dependentSchemas": {

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/accessioned_status"
-        },
-        {
             "$ref": "mixins.json#/aliases"
         },
         {
@@ -43,9 +40,6 @@
         },
         {
             "$ref": "mixins.json#/attribution"
-        },
-        {
-            "$ref": "mixins.json#/notes"
         },
         {
             "$ref": "mixins.json#/documents"

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -27,7 +27,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/accession"

--- a/src/igvfd/schemas/tissue.json
+++ b/src/igvfd/schemas/tissue.json
@@ -33,9 +33,6 @@
             "$ref": "mixins.json#/accession"
         },
         {
-            "$ref": "mixins.json#/alternate_accessions"
-        },
-        {
             "$ref": "mixins.json#/accessioned_status"
         },
         {

--- a/src/igvfd/schemas/treatment.json
+++ b/src/igvfd/schemas/treatment.json
@@ -17,9 +17,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {

--- a/src/igvfd/schemas/treatment.json
+++ b/src/igvfd/schemas/treatment.json
@@ -20,7 +20,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/aliases"

--- a/src/igvfd/schemas/treatment.json
+++ b/src/igvfd/schemas/treatment.json
@@ -32,9 +32,6 @@
             "$ref": "mixins.json#/submitted"
         },
         {
-            "$ref": "mixins.json#/notes"
-        },
-        {
             "$ref": "mixins.json#/documents"
         },
         {

--- a/src/igvfd/schemas/user.json
+++ b/src/igvfd/schemas/user.json
@@ -18,7 +18,7 @@
             "$ref": "mixins.json#/schema_version"
         },
         {
-            "$ref": "mixins.json#/uuid"
+            "$ref": "mixins.json#/basic_item"
         },
         {
             "$ref": "mixins.json#/shared_status"

--- a/src/igvfd/schemas/user.json
+++ b/src/igvfd/schemas/user.json
@@ -15,9 +15,6 @@
     "additionalProperties": false,
     "mixinProperties": [
         {
-            "$ref": "mixins.json#/schema_version"
-        },
-        {
             "$ref": "mixins.json#/basic_item"
         },
         {


### PR DESCRIPTION
Combined schema_version, notes and uuid into basic_item, a mixin that all items will have. (this means adding uuid and notes to some schemas that did not have them.  see chart)

Added submitter_comment in with submitted. There were only a few things that had “submitted” without submitter_comment and they all seemed like they should have it.

Added accessioned_status, alternate_accessions and collections in with accession.

Removed reviewer_comment which is not used anywhere.

Moved additional_description to technical_sample as that is the only place that it is used.

Sorted mixin lists to have abstract classes followed by basic item as that was the most common.  