### PR TITLE
IGVF-246-remove-uuid-as-unique-key-for-treatments

### DIFF
--- a/src/igvfd/types/treatment.py
+++ b/src/igvfd/types/treatment.py
@@ -10,7 +10,6 @@ from .base import (
 
 @collection(
     name='treatments',
-    unique_key='uuid',
     properties={
         'title': 'Treatment',
         'description': 'Listing of treatments',


### PR DESCRIPTION
Removed redundant uuid as unique identifier for treatments collections.