### PR TITLE
IGVF-288 Support for markdown pages

### DIFF
--- a/src/igvfd/schemas/changelogs/page.md
+++ b/src/igvfd/schemas/changelogs/page.md
@@ -2,7 +2,10 @@
 
 ### Schema version 3
 
-* Update schema version for deletion of unused properties
+* Remove `news`, `news_keywords`, and `news_excerpt` properties.
+* Remove the `rows` property from the `layout` dictionary.
+* Remove any `layout.block` elements that don't have an `@type` of `richtextblock`.
+* Change all remaining `layout.block` elements to an `@type` of `markdown`.
 
 ### Minor changes since schema version 2
 

--- a/src/igvfd/schemas/changelogs/page.md
+++ b/src/igvfd/schemas/changelogs/page.md
@@ -1,5 +1,9 @@
 ## Changelog for *`page.json`*
 
+### Schema version 3
+
+* Update schema version for deletion of unused properties
+
 ### Minor changes since schema version 2
 
 * Add `description`.

--- a/src/igvfd/schemas/changelogs/page.md
+++ b/src/igvfd/schemas/changelogs/page.md
@@ -7,6 +7,7 @@
 * Remove any `layout.block` elements that don't have an `@type` of `richtextblock`.
 * Change all remaining `layout.block` elements to an `@type` of `markdown`.
 * Add a `direction` property to each `layout.block`.
+* Enforce only defined schema properties allowed to be posted to the database in the `layout` and `layout.blocks` properties.
 
 ### Minor changes since schema version 2
 

--- a/src/igvfd/schemas/changelogs/page.md
+++ b/src/igvfd/schemas/changelogs/page.md
@@ -6,6 +6,7 @@
 * Remove the `rows` property from the `layout` dictionary.
 * Remove any `layout.block` elements that don't have an `@type` of `richtextblock`.
 * Change all remaining `layout.block` elements to an `@type` of `markdown`.
+* Add a `direction` property to each `layout.block`.
 
 ### Minor changes since schema version 2
 

--- a/src/igvfd/schemas/page.json
+++ b/src/igvfd/schemas/page.json
@@ -55,14 +55,33 @@
             "title": "Page Layout",
             "description": "Hierarchical description of the page layout.",
             "type": "object",
+            "additionalProperties": false,
             "formInput": "layout",
             "properties": {
                 "blocks": {
                     "type": "array",
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
+                            "@id": {
+                                "title": "Block ID",
+                                "description": "Unique identifier for this blocUnique identifier for this block.",
+                                "type": "string"
+                            },
+                            "@type": {
+                                "title": "Block Type",
+                                "description": "Indicates whether this block contains markdown or a component specification.",
+                                "type": "string"
+                            },
                             "body": {
+                                "title": "Block Body",
+                                "description": "The text content of this block.",
+                                "type": "string"
+                            },
+                            "direction": {
+                                "title": "Direction",
+                                "description": "The text language direction -- ltr or rtl.",
                                 "type": "string"
                             }
                         }

--- a/src/igvfd/schemas/page.json
+++ b/src/igvfd/schemas/page.json
@@ -25,41 +25,9 @@
             "$ref": "mixins.json#/attribution"
         }
     ],
-    "dependentSchemas": {
-        "news": {
-            "oneOf": [
-                {
-                    "required": [
-                        "news_excerpt"
-                    ],
-                    "properties": {
-                        "news": {
-                            "enum": [
-                                true
-                            ]
-                        }
-                    }
-                },
-                {
-                    "not": {
-                        "required": [
-                            "news_excerpt"
-                        ]
-                    },
-                    "properties": {
-                        "news": {
-                            "enum": [
-                                false
-                            ]
-                        }
-                    }
-                }
-            ]
-        }
-    },
     "properties": {
         "schema_version": {
-            "default": "2"
+            "default": "3"
         },
         "parent": {
             "title": "Parent Page",
@@ -83,55 +51,12 @@
             "description": "The name shown in the browser's title bar and tabs.",
             "type": "string"
         },
-        "news": {
-            "title": "News Post",
-            "type": "boolean",
-            "description": "Page is a news post"
-        },
-        "news_excerpt": {
-            "title": "News Excerpt",
-            "type": "string",
-            "description": "News post excerpt"
-        },
-        "news_keywords": {
-            "title": "News Keywords",
-            "type": "array",
-            "description": "Keywords to filter news posts.",
-            "minItems": 1,
-            "items": {
-                "title": "News Keyword",
-                "description": "A keyword for news post filtering.",
-                "type": "string",
-                "enum": [
-                    "Conferences",
-                    "DNA accessibility",
-                    "DNA binding",
-                    "DNA methylation",
-                    "DNA sequencing",
-                    "Genotyping",
-                    "Proteomics",
-                    "Replication timing",
-                    "RNA binding",
-                    "Transcription"
-                ]
-            }
-        },
         "layout": {
             "title": "Page Layout",
             "description": "Hierarchical description of the page layout.",
             "type": "object",
             "formInput": "layout",
             "properties": {
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "mapping": {
-                            "type": "object",
-                            "enabled": false
-                        }
-                    }
-                },
                 "blocks": {
                     "type": "array",
                     "items": {
@@ -139,36 +64,18 @@
                         "properties": {
                             "body": {
                                 "type": "string"
-                            },
-                            "image": {
-                                "type": "string",
-                                "linkTo": "Image"
-                            },
-                            "item": {
-                                "type": "string",
-                                "linkTo": "Item"
                             }
                         }
                     }
                 }
             },
             "default": {
-                "rows": [
-                    {
-                        "cols": [
-                            {
-                                "blocks": [
-                                    "#block1"
-                                ]
-                            }
-                        ]
-                    }
-                ],
                 "blocks": [
                     {
                         "@id": "#block1",
-                        "@type": "richtextblock",
-                        "body": "<p></p>"
+                        "@type": "markdown",
+                        "body": "<p></p>",
+                        "direction": "ltr"
                     }
                 ]
             }

--- a/src/igvfd/tests/conftest.py
+++ b/src/igvfd/tests/conftest.py
@@ -35,6 +35,7 @@ pytest_plugins = [
     'igvfd.tests.fixtures.schemas.document',
     'igvfd.tests.fixtures.schemas.publication',
     'igvfd.tests.fixtures.schemas.whole_organism',
+    'igvfd.tests.fixtures.schemas.page',
 ]
 
 

--- a/src/igvfd/tests/data/inserts/page.json
+++ b/src/igvfd/tests/data/inserts/page.json
@@ -5,22 +5,12 @@
         "status": "released",
         "uuid": "61edd6b2-bfdb-4db1-b950-8845ac37f65c",
         "layout": {
-            "rows": [
-                {
-                    "cols": [
-                        {
-                            "blocks": [
-                                "#block1"
-                            ]
-                        }
-                    ]
-                }
-            ],
             "blocks": [
                 {
                     "@id": "#block1",
-                    "@type": "richtextblock",
-                    "body": "<h1>Image Collection Landing Page</h1>"
+                    "@type": "markdown",
+                    "body": "# Image Collection Landing Page",
+                    "direction": "ltr"
                 }
             ]
         }
@@ -31,57 +21,30 @@
         "status": "released",
         "uuid": "27f9abd9-0081-4ade-8c82-95ec12b3a7dd",
         "layout": {
-            "rows": [
-                {
-                    "cols": [
-                        {
-                            "blocks": [
-                                "#block1"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "cols": [
-                        {
-                            "blocks": [
-                                "#block2"
-                            ]
-                        },
-                        {
-                            "blocks": [
-                                "#block3"
-                            ]
-                        },
-                        {
-                            "blocks": [
-                                "#block4"
-                            ]
-                        }
-                    ]
-                }
-            ],
             "blocks": [
                 {
                     "@id": "#block1",
-                    "@type": "richtextblock",
-                    "body": "<div class=\"project-info site-title\">\n    <h1>IGVF</h1>\n</div>\n<div id=\"info-box\" class=\"project-info text-panel\">\n  <p>The IGVF project dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.</p>\n</div>"
+                    "@type": "markdown",
+                    "body": "# IGVF\n\nThe IGVF project dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.",
+                    "direction": "ltr"
                 },
                 {
                     "@id": "#block2",
-                    "@type": "richtextblock",
-                    "body": "<h2>Transcriptome</h2>\n<p>Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.</p>"
+                    "@type": "markdown",
+                    "body": "## Transcriptome\n\nDuis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.",
+                    "direction": "ltr"
                 },
                 {
                     "@id": "#block3",
-                    "@type": "richtextblock",
-                    "body": "<h2>Regulation</h2>\n<p>Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum.</p>"
+                    "@type": "component",
+                    "body": "SAMPLE_COUNT\nlabel=Sample Count\ncolor=blue\n",
+                    "direction": "ltr"
                 },
                 {
                     "@id": "#block4",
-                    "@type": "teaserblock",
-                    "image": "/images/8a91ae78-731a-4a92-ae7c-273214be408a/",
-                    "body": "<h2>Chromatin Structure</h2>"
+                    "@type": "markdown",
+                    "body": "**Chromatin Structure**",
+                    "direction": "ltr"
                 }
             ]
         }
@@ -94,23 +57,12 @@
         "submitted_by": "massa.porta@varius.mauris",
         "uuid": "41c4ea4e-7a8e-4b91-8fe3-384d0adc8735",
         "layout": {
-            "rows": [
-                {
-                    "cols": [
-                        {
-                            "className": "col-md-12 class_override",
-                            "blocks": [
-                                "#block1"
-                            ]
-                        }
-                    ]
-                }
-            ],
             "blocks": [
                 {
                     "@id": "#block1",
-                    "@type": "richtextblock",
-                    "body": "<h1>Test Section</h1>"
+                    "@type": "markdown",
+                    "body": "# Test Section",
+                    "direction": "ltr"
                 }
             ]
         }
@@ -124,22 +76,12 @@
         "submitted_by": "massa.porta@varius.mauris",
         "uuid": "331928f7-d8f7-4ea6-b4e0-8d380fb22974",
         "layout": {
-            "rows": [
-                {
-                    "cols": [
-                        {
-                            "blocks": [
-                                "#block1"
-                            ]
-                        }
-                    ]
-                }
-            ],
             "blocks": [
                 {
                     "@id": "#block1",
-                    "@type": "richtextblock",
-                    "body": "<h1>Subpage</h1>"
+                    "@type": "markdown",
+                    "body": "# Subpage",
+                    "direction": "ltr"
                 }
             ]
         }
@@ -153,22 +95,201 @@
         "status": "in progress",
         "uuid": "83173355-31ff-4ca7-a259-e4af0f3a0169",
         "layout": {
-            "rows": [
-                {
-                    "cols": [
-                        {
-                            "blocks": [
-                                "#block1"
-                            ]
-                        }
-                    ]
-                }
-            ],
             "blocks": [
                 {
                     "@id": "#block1",
-                    "@type": "richtextblock",
-                    "body": "<h1>Subpage in progress (not logged should be unable to view)</h1>"
+                    "@type": "markdown",
+                    "body": "# Subpage in progress (not logged should be unable to view)",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "name": "help",
+        "title": "IGVF Help Documentation",
+        "lab": "j-michael-cherry",
+        "status": "released",
+        "submitted_by": "fytanaka@stanford.edu",
+        "uuid": "74aa2c4c-8767-4904-a442-1bf851fa56e4",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "Learn to use the [IGVF](https://igvf.org/) portal.",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/",
+        "name": "samples",
+        "title": "Samples",
+        "status": "released",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "uuid": "1b34820d-7fc1-457a-89c2-2a5accc3e8e6",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Samples\n\nSome help text about samples.",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/samples/",
+        "name": "cell-lines",
+        "title": "Cell Line",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "3f1d53de-6ad0-4978-beaf-ce31613063aa",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Cell Line Samples\n\nతెలుగు అనేది ద్రావిడ భాషల కుటుంబానికి చెందిన భాష. దీనిని మాట్లాడే ప్రజలు ప్రధానంగా ఆంధ్ర, తెలంగాణాలో ఉన్నారు. ఇది ఆ రాష్ట్రాలలో అధికార భాష. భారతదేశంలో ఒకటి కంటే ఎక్కువ రాష్ట్రాల్లో ప్రాథమిక అధికారిక భాషా హోదా కలిగిన కొద్ది భాషలలో హిందీ, బెంగాలీలతో పాటు ఇది కూడా ఉంది.",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/samples/",
+        "name": "differentiated-cells",
+        "title": "Differentiated Cells",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "8e95aaf6-8df3-40c7-8a58-098ec06e22bf",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Differentiated Cells\n\n日本語 は、日本国内や、かつての日本領だった国、そして日本人同士の間で使用されている言語。",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/",
+        "name": "donors",
+        "title": "Donors",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "c8733d26-8242-40f3-a663-ce6c7659a0b3",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Donor Help\n\nThis is some help text about donors.",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/donors/",
+        "name": "human-donors",
+        "title": "Human Donors",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "d91b048e-2d8a-4562-893d-93f0e68397c0",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Human Donor Help\n\nภาษาไทย หรือ ภาษาไทยกลาง เป็นภาษาในกลุ่มภาษาไท ซึ่งเป็นกลุ่มย่อยของตระกูลภาษาขร้า-ไท และเป็นภาษาราชการ และภาษาประจำชาติของประเทศไทย",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/donors/",
+        "name": "rodent-donors",
+        "title": "Rodent Donors",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "c0557916-f228-4895-8918-554eebb3c651",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Rodent Donor Help\n\n官話（又称北方话、官話方言、北方方言、北平官話、北语）為汉语的一支，主體分布在中国北部和西南部的大部分地区。若視漢語為一種語言，則官话是漢語的一级方言，下分北方官话、中原官话和南方官话；若視漢語為“漢語族”，視官話為獨立語言的話，則官話下有數支官話的方言。",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/",
+        "name": "ontologies",
+        "title": "Ontologies",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "b32b3cb7-e22c-4445-8465-e7636783437d",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Ontologies Help\n\nThis is some help text about ontologies.",
+                    "direction": "ltr"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/ontologies/",
+        "name": "assays",
+        "title": "Assays",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "235a1359-74bd-4b95-b0bb-70bf46f7856c",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Ontologies Help\n\nעִבְרִית (נקראת גם בשם: עברית מודרנית ישראלית) היא שפה שמית, ממשפחת השפות האפרו-אסיאתיות, הידועה כשפתם של היהודים ושל השומרונים.",
+                    "direction": "rtl"
+                }
+            ]
+        }
+    },
+    {
+        "parent": "/help/ontologies/",
+        "name": "phenotypes",
+        "title": "Phenotypes",
+        "lab": "j-michael-cherry",
+        "submitted_by": "fytanaka@stanford.edu",
+        "status": "released",
+        "uuid": "cb3e37da-af1b-4f6f-92a5-fd77f3e69154",
+        "layout": {
+            "blocks": [
+                {
+                    "@id": "#block1",
+                    "@type": "markdown",
+                    "body": "# Phenotypes Help\n\n한국어(韓國語)는 대한민국과 조선민주주의인민공화국의 공용어로, 대한민국에서는 한국어 또는 한국말이라고 부르고, 조선민주주의인민공화국에서는 조선어(朝鮮語) 또는 조선말이라고 부른다.",
+                    "direction": "ltr"
                 }
             ]
         }

--- a/src/igvfd/tests/data/inserts/user.json
+++ b/src/igvfd/tests/data/inserts/user.json
@@ -1742,11 +1742,9 @@
         "first_name": "Cypress",
         "last_name": "Testing",
         "lab": "/labs/j-michael-cherry/",
-        "viewing_groups": [
-            "IGVF"
-        ],
         "job_title": "Software Developer",
         "groups": [
+            "admin",
             "verified"
         ],
         "submits_for": [

--- a/src/igvfd/tests/fixtures/schemas/page.py
+++ b/src/igvfd/tests/fixtures/schemas/page.py
@@ -35,7 +35,7 @@ def page_v2(page):
         'news_excerpt': 'Don’t miss the abstract deadline for ENCODE Users Meeting.',
         'news_keywords': ['Conferences', 'Encyclopedia']
     })
-    item.update({item['layout']['rows']: [
+    item['layout']['rows'] = [
         {
             'cols': [
                 {
@@ -44,6 +44,6 @@ def page_v2(page):
                     ]
                 }
             ]
-        }]
-    })
+        }
+    ]
     return item

--- a/src/igvfd/tests/fixtures/schemas/page.py
+++ b/src/igvfd/tests/fixtures/schemas/page.py
@@ -6,21 +6,7 @@ def page(testapp):
     item = {
         'name': 'igvf-page',
         'title': 'IGVF Page',
-        'news': True,
-        'news_excerpt': 'Don’t miss the abstract deadline for ENCODE Users Meeting.',
-        'news_keywords': ['Conferences', 'Encyclopedia'],
         'layout': {
-            'rows': [
-                {
-                    'cols': [
-                        {
-                            'blocks': [
-                                '#block1'
-                            ]
-                        }
-                    ]
-                }
-            ],
             'blocks': [
                 {
                     '@id': '#block1',
@@ -28,7 +14,7 @@ def page(testapp):
                     'body': '<p></p>'
                 },
                 {
-                    '@id': '#block4',
+                    '@id': '#block2',
                     '@type': 'teaserblock',
                     'image': '/images/8a91ae78-731a-4a92-ae7c-273214be408a/',
                     'body': '<h2>Chromatin Structure</h2>',
@@ -45,5 +31,19 @@ def page_v2(page):
     item = page.copy()
     item.update({
         'schema_version': '2',
+        'news': True,
+        'news_excerpt': 'Don’t miss the abstract deadline for ENCODE Users Meeting.',
+        'news_keywords': ['Conferences', 'Encyclopedia']
+    })
+    item.update({item['layout']['rows']: [
+        {
+            'cols': [
+                {
+                    'blocks': [
+                        '#block1'
+                    ]
+                }
+            ]
+        }]
     })
     return item

--- a/src/igvfd/tests/fixtures/schemas/page.py
+++ b/src/igvfd/tests/fixtures/schemas/page.py
@@ -6,13 +6,33 @@ def page(testapp):
     item = {
         'name': 'igvf-page',
         'title': 'IGVF Page',
+        'news': True,
+        'news_excerpt': 'Don’t miss the abstract deadline for ENCODE Users Meeting.',
+        'news_keywords': ['Conferences', 'Encyclopedia'],
         'layout': {
+            'rows': [
+                {
+                    'cols': [
+                        {
+                            'blocks': [
+                                '#block1'
+                            ]
+                        }
+                    ]
+                }
+            ],
             'blocks': [
                 {
                     '@id': '#block1',
-                    '@type': 'markdown',
-                    'body': '<p></p>',
-                    'direction': 'ltr'
+                    '@type': 'richtextblock',
+                    'body': '<p></p>'
+                },
+                {
+                    '@id': '#block4',
+                    '@type': 'teaserblock',
+                    'image': '/images/8a91ae78-731a-4a92-ae7c-273214be408a/',
+                    'body': '<h2>Chromatin Structure</h2>',
+                    'href': '/about/chromatin-structure'
                 }
             ]
         }

--- a/src/igvfd/tests/fixtures/schemas/page.py
+++ b/src/igvfd/tests/fixtures/schemas/page.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.fixture
+def page(testapp):
+    item = {
+        'name': 'igvf-page',
+        'title': 'IGVF Page',
+        'layout': {
+            'blocks': [
+                {
+                    '@id': '#block1',
+                    '@type': 'markdown',
+                    'body': '<p></p>',
+                    'direction': 'ltr'
+                }
+            ]
+        }
+    }
+    return testapp.post_json('/page', item, status=201).json['@graph'][0]
+
+
+@pytest.fixture
+def page_v2(page):
+    item = page.copy()
+    item.update({
+        'schema_version': '2',
+    })
+    return item

--- a/src/igvfd/tests/fixtures/schemas/page.py
+++ b/src/igvfd/tests/fixtures/schemas/page.py
@@ -16,9 +16,7 @@ def page(testapp):
                 {
                     '@id': '#block2',
                     '@type': 'teaserblock',
-                    'image': '/images/8a91ae78-731a-4a92-ae7c-273214be408a/',
                     'body': '<h2>Chromatin Structure</h2>',
-                    'href': '/about/chromatin-structure'
                 }
             ]
         }
@@ -46,4 +44,13 @@ def page_v2(page):
             ]
         }
     ]
+    item['layout']['blocks'].append(
+        {
+            '@id': '#block2',
+            '@type': 'teaserblock',
+            'image': '/images/8a91ae78-731a-4a92-ae7c-273214be408a/',
+            'body': '<h2>Chromatin Structure</h2>',
+            'href': '/about/chromatin-structure'
+        }
+    )
     return item

--- a/src/igvfd/tests/test_upgrade_page.py
+++ b/src/igvfd/tests/test_upgrade_page.py
@@ -1,6 +1,25 @@
 import pytest
+from unittest import TestCase
 
 
 def test_page_upgrade_2_3(upgrader, page_v2):
     value = upgrader.upgrade('page', page_v2, current_version='2', target_version='3')
     assert value['schema_version'] == '3'
+    assert 'news' not in value
+    assert 'news_excerpt' not in value
+    assert 'news_keywords' not in value
+    assert 'layout' in value and 'rows' not in value['layout']
+    assert 'blocks' in value['layout']
+    assert len(value['layout']['blocks']) == 1
+    TestCase().assertListEqual(
+        value['layout']['blocks'],
+        sorted(
+            [
+                {
+                    '@id': '#block1',
+                    '@type': 'markdown',
+                    'body': '<p></p>'
+                }
+            ]
+        )
+    )

--- a/src/igvfd/tests/test_upgrade_page.py
+++ b/src/igvfd/tests/test_upgrade_page.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_page_upgrade_2_3(upgrader, page_v2):
+    value = upgrader.upgrade('page', page_v2, current_version='2', target_version='3')
+    assert value['schema_version'] == '3'

--- a/src/igvfd/tests/test_upgrade_page.py
+++ b/src/igvfd/tests/test_upgrade_page.py
@@ -13,13 +13,12 @@ def test_page_upgrade_2_3(upgrader, page_v2):
     assert len(value['layout']['blocks']) == 1
     TestCase().assertListEqual(
         value['layout']['blocks'],
-        sorted(
-            [
-                {
-                    '@id': '#block1',
-                    '@type': 'markdown',
-                    'body': '<p></p>'
-                }
-            ]
-        )
+        [
+            {
+                '@id': '#block1',
+                '@type': 'markdown',
+                'body': '<p></p>',
+                'direction': 'ltr'
+            }
+        ]
     )

--- a/src/igvfd/upgrade/page.py
+++ b/src/igvfd/upgrade/page.py
@@ -14,5 +14,17 @@ def page_1_2(value, system):
 
 @upgrade_step('page', '2', '3')
 def page_2_3(value, system):
-    # https://igvf.atlassian.net/browse/IGVF-288
-    return
+    if 'news' in value:
+        del value['news']
+    if 'news_excerpt' in value:
+        del value['news_keywords']
+    if 'news_keywords' in value:
+        del value['news_keywords']
+    if 'layout' in value:
+        if 'rows' in value['layout']:
+            del value['layout']['rows']
+        if 'blocks' in value['layout']:
+            richtextblocks = [block for block in value['layout']['blocks'] if block['@type'] == 'richtextblock']
+            for block in richtextblocks:
+                block.update({'@type': 'markdown'})
+            value['layout']['blocks'] = richtextblocks

--- a/src/igvfd/upgrade/page.py
+++ b/src/igvfd/upgrade/page.py
@@ -17,7 +17,7 @@ def page_2_3(value, system):
     if 'news' in value:
         del value['news']
     if 'news_excerpt' in value:
-        del value['news_keywords']
+        del value['news_excerpt']
     if 'news_keywords' in value:
         del value['news_keywords']
     if 'layout' in value:

--- a/src/igvfd/upgrade/page.py
+++ b/src/igvfd/upgrade/page.py
@@ -10,3 +10,9 @@ def page_1_2(value, system):
     if 'aliases' in value:
         if len(value['aliases']) == 0:
             del value['aliases']
+
+
+@upgrade_step('page', '2', '3')
+def page_2_3(value, system):
+    # https://igvf.atlassian.net/browse/IGVF-288
+    return

--- a/src/igvfd/upgrade/page.py
+++ b/src/igvfd/upgrade/page.py
@@ -26,5 +26,5 @@ def page_2_3(value, system):
         if 'blocks' in value['layout']:
             richtextblocks = [block for block in value['layout']['blocks'] if block['@type'] == 'richtextblock']
             for block in richtextblocks:
-                block.update({'@type': 'markdown'})
+                block.update({'@type': 'markdown', 'direction': 'ltr'})
             value['layout']['blocks'] = richtextblocks


### PR DESCRIPTION
Changelog

* Update the page schema to remove the `news` properties and the `rows` property from `layout`. Update the page test data for the new schema.
* Add a temporary test page to the test inserts.
* Remove `item` from schema.
* Add help pages to test inserts.
* Add local test inserts for the help page. Add a text direction to the default page object in the schema.
* Add upgrade steps and tests for pages.
* Fix linting errors.
* Fix incorrect indent in page test inserts.
* Restore much of page test inserts to pass view tests.
* Fix autopep8-detected formatting error.
* Add page upgrade to test configuration. Update page schema changelog.
* Update page test inserts.