### PR TITLE
IGVF-383 Fix schema misspellings

### DIFF
--- a/src/igvfd/schemas/award.json
+++ b/src/igvfd/schemas/award.json
@@ -134,7 +134,7 @@
         "project": {
             "title": "Project"
         },
-        "componenent": {
+        "component": {
             "title": "Component"
         },
         "status": {

--- a/src/igvfd/schemas/treatment.json
+++ b/src/igvfd/schemas/treatment.json
@@ -147,7 +147,7 @@
         "pH": {
             "title": "pH",
             "type": "number",
-            "description": "Final pH of the solution containing a chemical compund (if applicable)"
+            "description": "Final pH of the solution containing a chemical compound (if applicable)"
         },
         "purpose": {
             "title": "Purpose",


### PR DESCRIPTION
Fix two schema misspellings — one that causes a missing `components` property in award search results, and another minor misspelling on a description in treatment.json.