### PR TITLE
IGVF-435-reconcile-human-donor

### DIFF
--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -301,7 +301,7 @@
             "uniqueItems": true,
             "items": {
                 "title": "Reference",
-                "description": "A reference that provide smore information about the object.",
+                "description": "A reference that provides more information about the object.",
                 "type": "string",
                 "pattern": "^(PMID:[0-9]+|doi:10\\.[0-9]{4}[\\d\\s\\S\\:\\.\\/]+|PMCID:PMC[0-9]+|[0-9]{4}\\.[0-9]{4})$"
             }


### PR DESCRIPTION
Fixing a typo in the description of references in mixins schema.

Previously it said `A reference that provide smore information about the object` and now it says `A reference that provides more information`.