### PR TITLE
IGVF-375-facet-configs

### DIFF
--- a/config/nginx/production.conf
+++ b/config/nginx/production.conf
@@ -10,6 +10,9 @@ http {
     access_log /dev/stdout;
     resolver 127.0.0.1;
     client_max_body_size 1000m;
+    proxy_buffers 8 256k;
+    proxy_buffer_size 256k;
+    proxy_busy_buffers_size 256k;
 
     upstream app {
         server 127.0.0.1:6543;

--- a/src/igvfd/mappings/analysis_set.json
+++ b/src/igvfd/mappings/analysis_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "685f6849974e46a4be81454a4658a9b2",
-    "index_name": "analysis_set_685f6849",
+    "hash": "e9e67ce222eeae92a6160c3d890c53c3",
+    "index_name": "analysis_set_e9e67ce2",
     "item_type": "analysis_set",
     "mapping": {
         "dynamic_templates": [
@@ -160,7 +160,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -178,13 +246,190 @@
                         "type": "keyword"
                     },
                     "donors": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "accession": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "alternate_accessions": {
+                                "type": "keyword"
+                            },
+                            "award": {
+                                "type": "keyword"
+                            },
+                            "collections": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "ethnicities": {
+                                "type": "keyword"
+                            },
+                            "genotype": {
+                                "type": "keyword"
+                            },
+                            "individual_rodent": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "boolean"
+                            },
+                            "lab": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "phenotypic_features": {
+                                "type": "keyword"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "references": {
+                                "type": "keyword"
+                            },
+                            "related_donors": {
+                                "properties": {
+                                    "donor": {
+                                        "type": "keyword"
+                                    },
+                                    "relationship_type": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "revoke_detail": {
+                                "type": "keyword"
+                            },
+                            "rodent_identifier": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "sex": {
+                                "type": "keyword"
+                            },
+                            "source": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "strain": {
+                                "type": "keyword"
+                            },
+                            "strain_background": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "taxa": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "input_file_sets": {
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/biomarker.json
+++ b/src/igvfd/mappings/biomarker.json
@@ -1,6 +1,6 @@
 {
-    "hash": "e9eeaf99f66115d2547cd88f722df236",
-    "index_name": "biomarker_e9eeaf99",
+    "hash": "383216ce55f93c04ad46fe7fc38991d7",
+    "index_name": "biomarker_383216ce",
     "item_type": "biomarker",
     "mapping": {
         "dynamic_templates": [
@@ -151,7 +151,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "classification": {
                         "type": "keyword"
@@ -167,7 +235,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "name": {
                         "copy_to": "_all",

--- a/src/igvfd/mappings/construct_library.json
+++ b/src/igvfd/mappings/construct_library.json
@@ -1,6 +1,6 @@
 {
-    "hash": "eb14aa893fcf4c29b10de2eec897fe08",
-    "index_name": "construct_library_eb14aa89",
+    "hash": "1498e4608840fa5639168e32267f06d3",
+    "index_name": "construct_library_1498e460",
     "item_type": "construct_library",
     "mapping": {
         "dynamic_templates": [
@@ -162,7 +162,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -215,7 +283,63 @@
                         "type": "object"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"

--- a/src/igvfd/mappings/curated_set.json
+++ b/src/igvfd/mappings/curated_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "19652685e21c4fb485cfa1611a73c00c",
-    "index_name": "curated_set_19652685",
+    "hash": "1e7ab787f6dc7e9a3e1e529c12e4541d",
+    "index_name": "curated_set_1e7ab787",
     "item_type": "curated_set",
     "mapping": {
         "dynamic_templates": [
@@ -157,7 +157,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -182,7 +250,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/document.json
+++ b/src/igvfd/mappings/document.json
@@ -1,6 +1,6 @@
 {
-    "hash": "91a53a0899bfa8f4a14c46de05c4cbd1",
-    "index_name": "document_91a53a08",
+    "hash": "4679b62c391eb82d55ac802329988c18",
+    "index_name": "document_4679b62c",
     "item_type": "document",
     "mapping": {
         "dynamic_templates": [
@@ -195,7 +195,75 @@
                         "type": "object"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "characterization_method": {
                         "type": "keyword"
@@ -212,7 +280,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/human_donor.json
+++ b/src/igvfd/mappings/human_donor.json
@@ -1,6 +1,6 @@
 {
-    "hash": "0671084a0dafd2fa0428d9876f8b5e08",
-    "index_name": "human_donor_0671084a",
+    "hash": "b77b8988f07700fd333197571cb31e1b",
+    "index_name": "human_donor_b77b8988",
     "item_type": "human_donor",
     "mapping": {
         "dynamic_templates": [
@@ -158,7 +158,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -180,7 +248,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/in_vitro_system.json
+++ b/src/igvfd/mappings/in_vitro_system.json
@@ -1,6 +1,6 @@
 {
-    "hash": "f6bda4f4a786011d8d0fdf846d29e678",
-    "index_name": "in_vitro_system_f6bda4f4",
+    "hash": "d7f612070f67c815e0f9e582685b0116",
+    "index_name": "in_vitro_system_d7f61207",
     "item_type": "in_vitro_system",
     "mapping": {
         "dynamic_templates": [
@@ -164,13 +164,155 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "biomarkers": {
                         "type": "keyword"
                     },
                     "biosample_term": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "cell_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "developmental_slims": {
+                                "type": "keyword"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "organ_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "system_slims": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "classification": {
                         "type": "keyword"
@@ -191,7 +333,66 @@
                         "type": "text"
                     },
                     "disease_terms": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "documents": {
                         "type": "keyword"
@@ -215,7 +416,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -275,7 +532,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "starting_amount": {
                         "fields": {
@@ -321,7 +634,129 @@
                         "type": "keyword"
                     },
                     "treatments": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "amount": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "amount_units": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "duration": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "duration_units": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pH": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time_units": {
+                                "type": "keyword"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "purpose": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "source": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "temperature": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "temperature_units": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_id": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_name": {
+                                "type": "keyword"
+                            },
+                            "treatment_type": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "upper_bound_age": {
                         "fields": {

--- a/src/igvfd/mappings/lab.json
+++ b/src/igvfd/mappings/lab.json
@@ -1,6 +1,6 @@
 {
-    "hash": "a97d96a12043b14c834fed40d3e95024",
-    "index_name": "lab_a97d96a1",
+    "hash": "a3582c5175a44d4c89e19bbe1fc99a11",
+    "index_name": "lab_a3582c51",
     "item_type": "lab",
     "mapping": {
         "dynamic_templates": [
@@ -151,7 +151,75 @@
                         "type": "keyword"
                     },
                     "awards": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "creation_timestamp": {
                         "type": "keyword"

--- a/src/igvfd/mappings/measurement_set.json
+++ b/src/igvfd/mappings/measurement_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "9b354e02a386cffb714e0b010804a434",
-    "index_name": "measurement_set_9b354e02",
+    "hash": "2d83287b24c33f7a97666210cd4b043f",
+    "index_name": "measurement_set_2d83287b",
     "item_type": "measurement_set",
     "mapping": {
         "dynamic_templates": [
@@ -157,11 +157,147 @@
                         "type": "keyword"
                     },
                     "assay_term": {
-                        "copy_to": "_all",
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "assay_slims": {
+                                "type": "keyword"
+                            },
+                            "category_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "objective_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "copy_to": "_all",
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -182,10 +318,187 @@
                         "type": "keyword"
                     },
                     "donors": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "accession": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "alternate_accessions": {
+                                "type": "keyword"
+                            },
+                            "award": {
+                                "type": "keyword"
+                            },
+                            "collections": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "ethnicities": {
+                                "type": "keyword"
+                            },
+                            "genotype": {
+                                "type": "keyword"
+                            },
+                            "individual_rodent": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "boolean"
+                            },
+                            "lab": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "phenotypic_features": {
+                                "type": "keyword"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "references": {
+                                "type": "keyword"
+                            },
+                            "related_donors": {
+                                "properties": {
+                                    "donor": {
+                                        "type": "keyword"
+                                    },
+                                    "relationship_type": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "revoke_detail": {
+                                "type": "keyword"
+                            },
+                            "rodent_identifier": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "sex": {
+                                "type": "keyword"
+                            },
+                            "source": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "strain": {
+                                "type": "keyword"
+                            },
+                            "strain_background": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "taxa": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "library_construction_platform": {
                         "type": "keyword"

--- a/src/igvfd/mappings/modification.json
+++ b/src/igvfd/mappings/modification.json
@@ -1,6 +1,6 @@
 {
-    "hash": "68e50625eb2fe0318c352c355514c43c",
-    "index_name": "modification_68e50625",
+    "hash": "05fb1838476e6ea5cf8318c496abbef9",
+    "index_name": "modification_05fb1838",
     "item_type": "modification",
     "mapping": {
         "dynamic_templates": [
@@ -151,7 +151,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "cas": {
                         "type": "keyword"
@@ -169,7 +237,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"

--- a/src/igvfd/mappings/phenotypic_feature.json
+++ b/src/igvfd/mappings/phenotypic_feature.json
@@ -1,6 +1,6 @@
 {
-    "hash": "731a38ccd51020f60e85a868e0ab752a",
-    "index_name": "phenotypic_feature_731a38cc",
+    "hash": "b6a77f22f4681e5f59c9a5e539d7f048",
+    "index_name": "phenotypic_feature_b6a77f22",
     "item_type": "phenotypic_feature",
     "mapping": {
         "dynamic_templates": [
@@ -151,7 +151,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "creation_timestamp": {
                         "type": "keyword"
@@ -164,7 +232,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/primary_cell.json
+++ b/src/igvfd/mappings/primary_cell.json
@@ -1,6 +1,6 @@
 {
-    "hash": "08a3f4628a806b076b66ed617cde9323",
-    "index_name": "primary_cell_08a3f462",
+    "hash": "41bacce00f2c78a00977da6ac78aa1b1",
+    "index_name": "primary_cell_41bacce0",
     "item_type": "primary_cell",
     "mapping": {
         "dynamic_templates": [
@@ -164,13 +164,155 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "biomarkers": {
                         "type": "keyword"
                     },
                     "biosample_term": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "cell_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "developmental_slims": {
+                                "type": "keyword"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "organ_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "system_slims": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -188,7 +330,66 @@
                         "type": "text"
                     },
                     "disease_terms": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "documents": {
                         "type": "keyword"
@@ -209,7 +410,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -266,7 +523,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "starting_amount": {
                         "fields": {
@@ -297,7 +610,129 @@
                         "type": "keyword"
                     },
                     "treatments": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "amount": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "amount_units": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "duration": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "duration_units": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pH": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time_units": {
+                                "type": "keyword"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "purpose": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "source": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "temperature": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "temperature_units": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_id": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_name": {
+                                "type": "keyword"
+                            },
+                            "treatment_type": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "upper_bound_age": {
                         "fields": {

--- a/src/igvfd/mappings/publication.json
+++ b/src/igvfd/mappings/publication.json
@@ -1,6 +1,6 @@
 {
-    "hash": "b732d532edf1cb1ca23d7950e430884f",
-    "index_name": "publication_b732d532",
+    "hash": "402c1906ca5f1d73b2d4e9bd884343fa",
+    "index_name": "publication_402c1906",
     "item_type": "publication",
     "mapping": {
         "dynamic_templates": [
@@ -201,7 +201,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "creation_timestamp": {
                         "type": "keyword"
@@ -225,7 +293,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "notes": {
                         "type": "text"

--- a/src/igvfd/mappings/reference_data.json
+++ b/src/igvfd/mappings/reference_data.json
@@ -1,6 +1,6 @@
 {
-    "hash": "11866badc6cd045f7e2c05990928a417",
-    "index_name": "reference_data_11866bad",
+    "hash": "488e734286c9581a45e5da2cbc5cd29c",
+    "index_name": "reference_data_488e7342",
     "item_type": "reference_data",
     "mapping": {
         "dynamic_templates": [
@@ -161,7 +161,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -211,7 +279,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "md5sum": {
                         "type": "keyword"

--- a/src/igvfd/mappings/rodent_donor.json
+++ b/src/igvfd/mappings/rodent_donor.json
@@ -1,6 +1,6 @@
 {
-    "hash": "63535a6da5b9886d7186cd82ec2e7ccc",
-    "index_name": "rodent_donor_63535a6d",
+    "hash": "3e61eb1e295af5da35ed58157ef4773b",
+    "index_name": "rodent_donor_3e61eb1e",
     "item_type": "rodent_donor",
     "mapping": {
         "dynamic_templates": [
@@ -158,7 +158,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -188,7 +256,63 @@
                         "type": "boolean"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -218,7 +342,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "status": {
                         "type": "keyword"

--- a/src/igvfd/mappings/sequence_data.json
+++ b/src/igvfd/mappings/sequence_data.json
@@ -1,6 +1,6 @@
 {
-    "hash": "384dd38c3dacff1a7031934ce37e6542",
-    "index_name": "sequence_data_384dd38c",
+    "hash": "78d28aa870d2993c4811981a29f6e7fd",
+    "index_name": "sequence_data_78d28aa8",
     "item_type": "sequence_data",
     "mapping": {
         "dynamic_templates": [
@@ -158,7 +158,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -211,7 +279,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "maximum_read_length": {
                         "fields": {

--- a/src/igvfd/mappings/software.json
+++ b/src/igvfd/mappings/software.json
@@ -1,6 +1,6 @@
 {
-    "hash": "85f05f5d34c6ca5e98c1b7912c7615b9",
-    "index_name": "software_85f05f5d",
+    "hash": "fc75c3a96e662ef53551f4de2abcf76d",
+    "index_name": "software_fc75c3a9",
     "item_type": "software",
     "mapping": {
         "dynamic_templates": [
@@ -328,69 +328,7 @@
                         "type": "keyword"
                     },
                     "versions": {
-                        "properties": {
-                            "@id": {
-                                "type": "keyword"
-                            },
-                            "@type": {
-                                "type": "keyword"
-                            },
-                            "aliases": {
-                                "type": "keyword"
-                            },
-                            "award": {
-                                "type": "keyword"
-                            },
-                            "creation_timestamp": {
-                                "type": "keyword"
-                            },
-                            "description": {
-                                "type": "text"
-                            },
-                            "download_id": {
-                                "type": "keyword"
-                            },
-                            "downloaded_url": {
-                                "type": "keyword"
-                            },
-                            "lab": {
-                                "type": "keyword"
-                            },
-                            "name": {
-                                "type": "keyword"
-                            },
-                            "notes": {
-                                "type": "text"
-                            },
-                            "references": {
-                                "type": "keyword"
-                            },
-                            "schema_version": {
-                                "type": "keyword"
-                            },
-                            "software": {
-                                "type": "keyword"
-                            },
-                            "status": {
-                                "type": "keyword"
-                            },
-                            "submitted_by": {
-                                "type": "keyword"
-                            },
-                            "submitter_comment": {
-                                "type": "keyword"
-                            },
-                            "summary": {
-                                "type": "keyword"
-                            },
-                            "uuid": {
-                                "type": "keyword"
-                            },
-                            "version": {
-                                "type": "keyword"
-                            }
-                        },
-                        "type": "object"
+                        "type": "keyword"
                     }
                 },
                 "type": "object"

--- a/src/igvfd/mappings/software_version.json
+++ b/src/igvfd/mappings/software_version.json
@@ -1,6 +1,6 @@
 {
-    "hash": "64aa9770c0cb05ca38a9f8d1b9257e44",
-    "index_name": "software_version_64aa9770",
+    "hash": "a86d2859168c281dbd17fda912da4544",
+    "index_name": "software_version_a86d2859",
     "item_type": "software_version",
     "mapping": {
         "dynamic_templates": [
@@ -151,36 +151,6 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
-                    },
-                    "creation_timestamp": {
-                        "type": "keyword"
-                    },
-                    "description": {
-                        "type": "text"
-                    },
-                    "download_id": {
-                        "type": "keyword"
-                    },
-                    "downloaded_url": {
-                        "type": "keyword"
-                    },
-                    "lab": {
-                        "type": "keyword"
-                    },
-                    "name": {
-                        "type": "keyword"
-                    },
-                    "notes": {
-                        "type": "text"
-                    },
-                    "references": {
-                        "type": "keyword"
-                    },
-                    "schema_version": {
-                        "type": "keyword"
-                    },
-                    "software": {
                         "properties": {
                             "@id": {
                                 "type": "keyword"
@@ -191,7 +161,10 @@
                             "aliases": {
                                 "type": "keyword"
                             },
-                            "award": {
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
                                 "type": "keyword"
                             },
                             "creation_timestamp": {
@@ -200,7 +173,7 @@
                             "description": {
                                 "type": "text"
                             },
-                            "lab": {
+                            "end_date": {
                                 "type": "keyword"
                             },
                             "name": {
@@ -209,13 +182,16 @@
                             "notes": {
                                 "type": "text"
                             },
-                            "references": {
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
                                 "type": "keyword"
                             },
                             "schema_version": {
                                 "type": "keyword"
                             },
-                            "source_url": {
+                            "start_date": {
                                 "type": "keyword"
                             },
                             "status": {
@@ -233,17 +209,103 @@
                             "title": {
                                 "type": "keyword"
                             },
-                            "used_by": {
+                            "url": {
                                 "type": "keyword"
                             },
                             "uuid": {
                                 "type": "keyword"
                             },
-                            "versions": {
+                            "viewing_group": {
                                 "type": "keyword"
                             }
                         },
                         "type": "object"
+                    },
+                    "creation_timestamp": {
+                        "type": "keyword"
+                    },
+                    "description": {
+                        "type": "text"
+                    },
+                    "download_id": {
+                        "type": "keyword"
+                    },
+                    "downloaded_url": {
+                        "type": "keyword"
+                    },
+                    "lab": {
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "name": {
+                        "type": "keyword"
+                    },
+                    "notes": {
+                        "type": "text"
+                    },
+                    "references": {
+                        "type": "keyword"
+                    },
+                    "schema_version": {
+                        "type": "keyword"
+                    },
+                    "software": {
+                        "type": "keyword"
                     },
                     "status": {
                         "type": "keyword"

--- a/src/igvfd/mappings/technical_sample.json
+++ b/src/igvfd/mappings/technical_sample.json
@@ -1,6 +1,6 @@
 {
-    "hash": "cdcc588c9ff42c7c91353bb2700cefb3",
-    "index_name": "technical_sample_cdcc588c",
+    "hash": "b218ff2158878ab36393168bb281b14a",
+    "index_name": "technical_sample_b218ff21",
     "item_type": "technical_sample",
     "mapping": {
         "dynamic_templates": [
@@ -158,7 +158,75 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -182,7 +250,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -209,7 +333,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "starting_amount": {
                         "fields": {
@@ -236,7 +416,81 @@
                         "type": "keyword"
                     },
                     "technical_sample_term": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "cell_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "developmental_slims": {
+                                "type": "keyword"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "organ_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "system_slims": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "url": {
                         "type": "keyword"

--- a/src/igvfd/mappings/tissue.json
+++ b/src/igvfd/mappings/tissue.json
@@ -1,6 +1,6 @@
 {
-    "hash": "cb2a4a939a31aaea82b562f8f5d527c7",
-    "index_name": "tissue_cb2a4a93",
+    "hash": "84cfa5dcee9f11e8fdcea14833fc7376",
+    "index_name": "tissue_84cfa5dc",
     "item_type": "tissue",
     "mapping": {
         "dynamic_templates": [
@@ -164,13 +164,155 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "biomarkers": {
                         "type": "keyword"
                     },
                     "biosample_term": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "cell_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "developmental_slims": {
+                                "type": "keyword"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "organ_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "system_slims": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "ccf_id": {
                         "type": "keyword"
@@ -191,7 +333,66 @@
                         "type": "text"
                     },
                     "disease_terms": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "documents": {
                         "type": "keyword"
@@ -212,7 +413,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -275,7 +532,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "starting_amount": {
                         "fields": {

--- a/src/igvfd/mappings/treatment.json
+++ b/src/igvfd/mappings/treatment.json
@@ -1,6 +1,6 @@
 {
-    "hash": "918391eb756540e89a13eeaebc3b2048",
-    "index_name": "treatment_918391eb",
+    "hash": "1714d65b0d9ff27d83aa9bb6b643006a",
+    "index_name": "treatment_1714d65b",
     "item_type": "treatment",
     "mapping": {
         "dynamic_templates": [
@@ -220,7 +220,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "status": {
                         "type": "keyword"

--- a/src/igvfd/mappings/whole_organism.json
+++ b/src/igvfd/mappings/whole_organism.json
@@ -1,6 +1,6 @@
 {
-    "hash": "db23de719320ec69d3e94e8927ce4d98",
-    "index_name": "whole_organism_db23de71",
+    "hash": "2df544c03ef4ee28684eb58d734ed469",
+    "index_name": "whole_organism_2df544c0",
     "item_type": "whole_organism",
     "mapping": {
         "dynamic_templates": [
@@ -164,13 +164,214 @@
                         "type": "keyword"
                     },
                     "award": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "component": {
+                                "type": "keyword"
+                            },
+                            "contact_pi": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "end_date": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pis": {
+                                "type": "keyword"
+                            },
+                            "project": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "start_date": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "viewing_group": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "biomarkers": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "award": {
+                                "type": "keyword"
+                            },
+                            "classification": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "gene": {
+                                "type": "keyword"
+                            },
+                            "lab": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "name_quantification": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "quantification": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "biosample_term": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "cell_slims": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "developmental_slims": {
+                                "type": "keyword"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "organ_slims": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "system_slims": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "collections": {
                         "type": "keyword"
@@ -188,7 +389,66 @@
                         "type": "text"
                     },
                     "disease_terms": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "ancestors": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "deprecated_ntr_terms": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "is_a": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "synonyms": {
+                                "type": "keyword"
+                            },
+                            "term_id": {
+                                "type": "keyword"
+                            },
+                            "term_name": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "documents": {
                         "type": "keyword"
@@ -209,7 +469,63 @@
                         "type": "keyword"
                     },
                     "lab": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "lot_id": {
                         "type": "keyword"
@@ -260,7 +576,63 @@
                         "type": "keyword"
                     },
                     "source": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "awards": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "institute_label": {
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pi": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "starting_amount": {
                         "fields": {
@@ -291,7 +663,129 @@
                         "type": "keyword"
                     },
                     "treatments": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "amount": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "amount_units": {
+                                "type": "keyword"
+                            },
+                            "creation_timestamp": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "duration": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "duration_units": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "pH": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "post_treatment_time_units": {
+                                "type": "keyword"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "purpose": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "source": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "temperature": {
+                                "fields": {
+                                    "raw": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "store": true,
+                                "type": "float"
+                            },
+                            "temperature_units": {
+                                "type": "keyword"
+                            },
+                            "title": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_id": {
+                                "type": "keyword"
+                            },
+                            "treatment_term_name": {
+                                "type": "keyword"
+                            },
+                            "treatment_type": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "upper_bound_age": {
                         "fields": {

--- a/src/igvfd/schemas/measurement_set.json
+++ b/src/igvfd/schemas/measurement_set.json
@@ -116,7 +116,7 @@
     },
     "fuzzy_searchable_fields": [
         "@type",
-        "assay_term",
+        "assay_term.term_name",
         "protocol"
     ],
     "changelog": "/profiles/changelogs/measurement_set.md"

--- a/src/igvfd/searches/configs/analysis_set.py
+++ b/src/igvfd/searches/configs/analysis_set.py
@@ -7,25 +7,44 @@ from snovault.elasticsearch.searches.configs import search_config
 def analysis_set():
     return {
         'facets': {
+            'collections': {
+                'title': 'Collections',
+            },
+            'donors.taxa': {
+                'title': 'Donor Taxa',
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
             'status': {
                 'title': 'Status'
             },
-            'sample': {
-                'title': 'Sample'
-            },
-            'donor': {
-                'title': 'Donor'
-            },
-            'lab': {
-                'title': 'Lab'
-            },
-            'award': {
-                'title': 'Award'
-            },
-            'input_file_sets': {
-                'title': 'Input File Sets'
-            }
         },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'donors.taxa',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'accession': {
                 'title': 'Accession'
@@ -42,8 +61,8 @@ def analysis_set():
             'sample': {
                 'title': 'Sample'
             },
-            'donor': {
-                'title': 'Donor'
+            'donors': {
+                'title': 'Donors'
             },
             'lab': {
                 'title': 'Lab'

--- a/src/igvfd/searches/configs/assay_term.py
+++ b/src/igvfd/searches/configs/assay_term.py
@@ -6,6 +6,36 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def assay_term():
     return {
+        'facets': {
+            'assay_slims': {
+                'title': 'Assay Type',
+            },
+            'category_slims': {
+                'title': 'Assay Category',
+            },
+            'objective_slims': {
+                'title': 'Assay Objective',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Assay',
+                'facet_fields': [
+                    'assay_slims',
+                    'category_slims',
+                    'objective_slims',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/biomarker.py
+++ b/src/igvfd/searches/configs/biomarker.py
@@ -16,10 +16,30 @@ def biomarker():
             'classification': {
                 'title': 'Classification'
             },
-            'gene': {
-                'title': 'Gene'
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
             },
         },
+        'facet_groups': [
+            {
+                'title': 'Biomarker',
+                'facet_fields': [
+                    'name',
+                    'quantification',
+                    'classification',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/construct_library.py
+++ b/src/igvfd/searches/configs/construct_library.py
@@ -10,10 +10,10 @@ def cell_line():
             'status': {
                 'title': 'Status'
             },
-            'award': {
+            'award.component': {
                 'title': 'Award'
             },
-            'lab': {
+            'lab.title': {
                 'title': 'Lab'
             },
             'scope': {
@@ -33,7 +33,7 @@ def cell_line():
             'status': {
                 'title': 'Status'
             },
-            'lab.title': {
+            'lab': {
                 'title': 'Lab'
             },
             'scope': {

--- a/src/igvfd/searches/configs/curated_set.py
+++ b/src/igvfd/searches/configs/curated_set.py
@@ -10,25 +10,45 @@ def curated_set():
             'status': {
                 'title': 'Status'
             },
-            'sample': {
-                'title': 'Sample'
-            },
-            'donor': {
-                'title': 'Donor'
-            },
-            'lab': {
+            'lab.title': {
                 'title': 'Lab'
             },
-            'award': {
+            'award.component': {
                 'title': 'Award'
             },
             'taxa': {
                 'title': 'Taxa'
             },
+            'collections': {
+                'title': 'Collections'
+            },
             'curated_set_type': {
                 'title': 'Curated Set Type'
             },
         },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'taxa',
+                    'curated_set_type',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'accession': {
                 'title': 'Accession'

--- a/src/igvfd/searches/configs/document.py
+++ b/src/igvfd/searches/configs/document.py
@@ -6,6 +6,45 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def document():
     return {
+        'facets': {
+            'document_type': {
+                'title': 'Document Type'
+            },
+            'characterization_method': {
+                'title': 'Characterization Method'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Document',
+                'facet_fields': [
+                    'document_type',
+                    'characterization_method',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/gene.py
+++ b/src/igvfd/searches/configs/gene.py
@@ -6,6 +6,14 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def gene():
     return {
+        'facets': {
+            'taxa': {
+                'title': 'Taxa'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/human_donor.py
+++ b/src/igvfd/searches/configs/human_donor.py
@@ -6,6 +6,49 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def human_donor():
     return {
+        'facets': {
+            'ethnicities': {
+                'title': 'Ethnicities'
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
+        'facet_groups': [
+            {
+                'title': 'Donor',
+                'facet_fields': [
+                    'ethnicities',
+                    'sex',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/human_genomic_variant.py
+++ b/src/igvfd/searches/configs/human_genomic_variant.py
@@ -6,6 +6,14 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def human_genomic_variant():
     return {
+        'facets': {
+            'assembly': {
+                'title': 'Genome Assembly'
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/in_vitro_system.py
+++ b/src/igvfd/searches/configs/in_vitro_system.py
@@ -6,6 +6,69 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def in_vitro_system():
     return {
+        'facets': {
+            'biosample_term.term_name': {
+                'title': 'Biosample Term',
+            },
+            'disease_terms.term_name': {
+                'title': 'Disease Terms',
+            },
+            'treatments.treatment_term_name': {
+                'title': 'Treatments',
+            },
+            'taxa': {
+                'title': 'Taxa',
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'classification': {
+                'title': 'Classification',
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'source.title': {
+                'title': 'Source',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'biosample_term.term_name',
+                    'disease_terms.term_name',
+                    'treatments.treatment_term_name',
+                    'taxa',
+                    'sex',
+                    'classification',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/lab.py
+++ b/src/igvfd/searches/configs/lab.py
@@ -7,6 +7,12 @@ from snovault.elasticsearch.searches.configs import search_config
 def lab():
     return {
         'facets': {
+            'awards.component': {
+                'title': 'Award'
+            },
+            'institute_label': {
+                'title': 'Institute'
+            },
             'status': {
                 'title': 'Status'
             },

--- a/src/igvfd/searches/configs/measurement_set.py
+++ b/src/igvfd/searches/configs/measurement_set.py
@@ -7,28 +7,48 @@ from snovault.elasticsearch.searches.configs import search_config
 def measurement_set():
     return {
         'facets': {
+            'donors.taxa': {
+                'title': 'Donor Taxa',
+            },
+            'assay_term.term_name': {
+                'title': 'Assay Term'
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
             'status': {
                 'title': 'Status'
             },
-            'sample': {
-                'title': 'Sample'
-            },
-            'donor': {
-                'title': 'Donor'
-            },
-            'lab': {
-                'title': 'Lab'
-            },
-            'award': {
-                'title': 'Award'
-            },
-            'assay_term': {
-                'title': 'Assay Term'
-            },
-            'protocol': {
-                'title': 'Protocol'
-            },
         },
+        'facet_groups': [
+            {
+                'title': 'File Set',
+                'facet_fields': [
+                    'donors.taxa',
+                    'assay_term.term_name',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'accession': {
                 'title': 'Accession'

--- a/src/igvfd/searches/configs/modification.py
+++ b/src/igvfd/searches/configs/modification.py
@@ -12,8 +12,39 @@ def modification():
             },
             'modality': {
                 'title': 'Modality'
-            }
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
         },
+        'facet_groups': [
+            {
+                'title': 'Modification',
+                'facet_fields': [
+                    'cas',
+                    'modality',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'
@@ -35,6 +66,9 @@ def modification():
             },
             'product_id': {
                 'title': 'Product ID'
+            },
+            'lab': {
+                'title': 'Lab'
             }
         }
     }

--- a/src/igvfd/searches/configs/phenotype_term.py
+++ b/src/igvfd/searches/configs/phenotype_term.py
@@ -6,6 +6,11 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def phenotype_term():
     return {
+        'facets': {
+            'status': {
+                'title': 'Status'
+            },
+        },
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/phenotypic_feature.py
+++ b/src/igvfd/searches/configs/phenotypic_feature.py
@@ -6,6 +6,17 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def phenotypic_feature():
     return {
+        'facets': {
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
         'columns': {
             'uuid': {
                 'title': 'UUID'
@@ -16,5 +27,8 @@ def phenotypic_feature():
             'status': {
                 'title': 'Status'
             },
+            'lab': {
+                'title': 'Lab'
+            }
         }
     }

--- a/src/igvfd/searches/configs/primary_cell.py
+++ b/src/igvfd/searches/configs/primary_cell.py
@@ -6,6 +6,68 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def primary_cell():
     return {
+        'facets': {
+            'biosample_term.term_name': {
+                'title': 'Biosample Term',
+            },
+            'disease_terms.term_name': {
+                'title': 'Disease Terms',
+            },
+            'treatments.treatment_term_name': {
+                'title': 'Treatments',
+            },
+            'taxa': {
+                'title': 'Taxa',
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'donors.taxa': {
+                'title': 'Donor Taxa',
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'source.title': {
+                'title': 'Source',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'biosample_term.term_name',
+                    'disease_terms.term_name',
+                    'treatments.treatment_term_name',
+                    'taxa',
+                    'sex',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/publication.py
+++ b/src/igvfd/searches/configs/publication.py
@@ -6,6 +6,41 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def publication():
     return {
+        'facets': {
+            'published_by': {
+                'title': 'Published By'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Publication',
+                'facet_fields': [
+                    'published_by',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'title': {
                 'title': 'Title'

--- a/src/igvfd/searches/configs/reference_data.py
+++ b/src/igvfd/searches/configs/reference_data.py
@@ -6,6 +6,62 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def reference_data():
     return {
+        'facets': {
+            'file_format': {
+                'title': 'File Format'
+            },
+            'content_type': {
+                'title': 'Content Type'
+            },
+            'assembly': {
+                'title': 'Assembly'
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'upload_status': {
+                'title': 'Upload Status'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
+        'facet_groups': [
+            {
+                'title': 'Format',
+                'facet_fields': [
+                    'file_format',
+                    'content_type',
+                ],
+            },
+            {
+                'title': 'Analysis',
+                'facet_fields': [
+                    'assembly',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'upload_status',
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'
@@ -18,6 +74,9 @@ def reference_data():
             },
             'file_format': {
                 'title': 'File Format'
+            },
+            'lab': {
+                'title': 'Lab'
             },
         }
     }

--- a/src/igvfd/searches/configs/rodent_donor.py
+++ b/src/igvfd/searches/configs/rodent_donor.py
@@ -6,6 +6,53 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def rodent_donor():
     return {
+        'facets': {
+            'strain_background': {
+                'title': 'Strain Background',
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'source.title': {
+                'title': 'Source',
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
+        'facet_groups': [
+            {
+                'title': 'Donor',
+                'facet_fields': [
+                    'strain_background',
+                    'sex',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collection',
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/sample_term.py
+++ b/src/igvfd/searches/configs/sample_term.py
@@ -6,6 +6,40 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def sample_term():
     return {
+        'facets': {
+            'organ_slims': {
+                'title': 'Organ',
+            },
+            'cell_slims': {
+                'title': 'Cell',
+            },
+            'developmental_slims': {
+                'title': 'Developmental Slims',
+            },
+            'system_slims': {
+                'title': 'System Slims',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'organ_slims',
+                    'cell_slims',
+                    'developmental_slims',
+                    'system_slims',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/sequence_data.py
+++ b/src/igvfd/searches/configs/sequence_data.py
@@ -6,6 +6,57 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def sequence_data():
     return {
+        'facets': {
+            'file_format': {
+                'title': 'File Format'
+            },
+            'content_type': {
+                'title': 'Content Type'
+            },
+            'illumina_read_type': {
+                'title': 'Illumina Read Type'
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'upload_status': {
+                'title': 'Upload Status'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
+        'facet_groups': [
+            {
+                'title': 'Format',
+                'facet_fields': [
+                    'file_format',
+                    'content_type',
+                    'illumina_read_type',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'upload_status',
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'
@@ -18,6 +69,9 @@ def sequence_data():
             },
             'file_format': {
                 'title': 'File Format'
+            },
+            'lab': {
+                'title': 'Lab'
             },
         }
     }

--- a/src/igvfd/searches/configs/software.py
+++ b/src/igvfd/searches/configs/software.py
@@ -8,15 +8,39 @@ def software():
     return {
         'facets': {
             'used_by': {
-                'title': 'Used by'
-            },
-            'award.component': {
-                'title': 'Award'
+                'title': 'Used By'
             },
             'lab.title': {
                 'title': 'Lab'
             },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
         },
+        'facet_groups': [
+            {
+                'title': 'Software',
+                'facet_fields': [
+                    'used_by',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'title': {
                 'title': 'Title'
@@ -39,7 +63,7 @@ def software():
             'used_by': {
                 'title': 'Used by'
             },
-            'lab.title': {
+            'lab': {
                 'title': 'Lab'
             },
         }

--- a/src/igvfd/searches/configs/software_version.py
+++ b/src/igvfd/searches/configs/software_version.py
@@ -7,6 +7,12 @@ from snovault.elasticsearch.searches.configs import search_config
 def software_version():
     return {
         'facets': {
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
             'status': {
                 'title': 'Status'
             },

--- a/src/igvfd/searches/configs/source.py
+++ b/src/igvfd/searches/configs/source.py
@@ -5,4 +5,21 @@ from snovault.elasticsearch.searches.configs import search_config
     name='Source'
 )
 def source():
-    return {}
+    return {
+        'facets': {
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'columns': {
+            'title': {
+                'title': 'Title'
+            },
+            'description': {
+                'title': 'Description',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        }
+    }

--- a/src/igvfd/searches/configs/technical_sample.py
+++ b/src/igvfd/searches/configs/technical_sample.py
@@ -6,6 +6,49 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def technical_sample():
     return {
+        'facets': {
+            'technical_sample_term.term_name': {
+                'title': 'Technical Sample Term',
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'source.title': {
+                'title': 'Source',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'technical_sample_term.term_name',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/tissue.py
+++ b/src/igvfd/searches/configs/tissue.py
@@ -6,6 +6,65 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def tissue():
     return {
+        'facets': {
+            'biosample_term.term_name': {
+                'title': 'Biosample Term',
+            },
+            'disease_terms.term_name': {
+                'title': 'Disease Terms',
+            },
+            'treatments.treatment_term_name': {
+                'title': 'Treatments',
+            },
+            'taxa': {
+                'title': 'Taxa',
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'source.title': {
+                'title': 'Source',
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'biosample_term.term_name',
+                    'disease_terms.term_name',
+                    'treatments.treatment_term_name',
+                    'taxa',
+                    'sex',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/treatment.py
+++ b/src/igvfd/searches/configs/treatment.py
@@ -6,6 +6,41 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def treatment():
     return {
+        'facets': {
+            'purpose': {
+                'title': 'Purpose'
+            },
+            'treatment_type': {
+                'title': 'Treatment Type'
+            },
+            'source.title': {
+                'title': 'Source'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        },
+        'facet_groups': [
+            {
+                'title': 'Treatment',
+                'facet_fields': [
+                    'purpose',
+                    'treatment_type',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'source.title',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            }
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/whole_organism.py
+++ b/src/igvfd/searches/configs/whole_organism.py
@@ -6,6 +6,65 @@ from snovault.elasticsearch.searches.configs import search_config
 )
 def whole_organism():
     return {
+        'facets': {
+            'taxa': {
+                'title': 'Taxa'
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'treatments.treatment_type': {
+                'title': 'Treatments'
+            },
+            'biomarkers.classification': {
+                'title': 'Biomarkers'
+            },
+            'source.title': {
+                'title': 'Source'
+            },
+            'biosample_term.term_name': {
+                'title': 'Biosample Term'
+            },
+            'disease_terms.term_name': {
+                'title': 'Disease'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'taxa',
+                    'sex',
+                    'treatments.treatment_type',
+                    'biomarkers.classification',
+                    'biosample_term.term_name',
+                    'disease_terms.term_name',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'lab.title',
+                    'award.component',
+                    'source.title',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/types/biomarker.py
+++ b/src/igvfd/types/biomarker.py
@@ -3,7 +3,7 @@ from snovault import (
     collection,
     load_schema,
 )
-
+from snovault.util import Path
 from .base import (
     Item,
 )
@@ -19,6 +19,10 @@ from .base import (
 class Biomarker(Item):
     item_type = 'biomarker'
     schema = load_schema('igvfd:schemas/biomarker.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'name', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     @calculated_property(
         schema={

--- a/src/igvfd/types/document.py
+++ b/src/igvfd/types/document.py
@@ -3,6 +3,7 @@ from snovault import (
     collection,
     load_schema,
 )
+from snovault.util import Path
 from .base import (
     Item,
     paths_filtered_by_status,
@@ -21,3 +22,7 @@ from .base import (
 class Document(ItemWithAttachment, Item):
     item_type = 'document'
     schema = load_schema('igvfd:schemas/document.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]

--- a/src/igvfd/types/donor.py
+++ b/src/igvfd/types/donor.py
@@ -3,7 +3,7 @@ from snovault import (
     collection,
     load_schema,
 )
-
+from snovault.util import Path
 from .base import (
     Item,
 )
@@ -35,6 +35,10 @@ class Donor(Item):
 class HumanDonor(Donor):
     item_type = 'human_donor'
     schema = load_schema('igvfd:schemas/human_donor.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
 
 @collection(
@@ -48,6 +52,11 @@ class HumanDonor(Donor):
 class RodentDonor(Donor):
     item_type = 'rodent_donor'
     schema = load_schema('igvfd:schemas/rodent_donor.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+    ]
 
     def unique_keys(self, properties):
         keys = super(RodentDonor, self).unique_keys(properties)

--- a/src/igvfd/types/file.py
+++ b/src/igvfd/types/file.py
@@ -25,6 +25,8 @@ from snovault.attachment import InternalRedirect
 
 from snovault.schema_utils import schema_validator
 
+from snovault.util import Path
+
 from igvfd.types.base import Item
 
 from igvfd.upload_credentials import get_s3_client
@@ -185,6 +187,10 @@ class File(Item):
 class SequenceData(File):
     item_type = 'sequence_data'
     schema = load_schema('igvfd:schemas/sequence_data.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     def unique_keys(self, properties):
         keys = super(File, self).unique_keys(properties)
@@ -212,6 +218,10 @@ class SequenceData(File):
 class ReferenceData(File):
     item_type = 'reference_data'
     schema = load_schema('igvfd:schemas/reference_data.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     def unique_keys(self, properties):
         keys = super(File, self).unique_keys(properties)

--- a/src/igvfd/types/file_set.py
+++ b/src/igvfd/types/file_set.py
@@ -4,6 +4,7 @@ from snovault import (
     collection,
     load_schema,
 )
+from snovault.util import Path
 
 from .base import (
     Item
@@ -36,6 +37,11 @@ class FileSet(Item):
 class AnalysisSet(FileSet):
     item_type = 'analysis_set'
     schema = load_schema('igvfd:schemas/analysis_set.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('donors', include=['@id', 'taxa']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     @calculated_property(
         schema={
@@ -73,6 +79,10 @@ class AnalysisSet(FileSet):
 class CuratedSet(FileSet):
     item_type = 'curated_set'
     schema = load_schema('igvfd:schemas/curated_set.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
 
 @collection(
@@ -85,6 +95,12 @@ class CuratedSet(FileSet):
 class MeasurementSet(FileSet):
     item_type = 'measurement_set'
     schema = load_schema('igvfd:schemas/measurement_set.json')
+    embedded_with_frame = [
+        Path('assay_term', include=['@id', 'term_name']),
+        Path('award', include=['@id', 'component']),
+        Path('donors', include=['@id', 'taxa']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     @calculated_property(
         condition='multiome_size',
@@ -127,3 +143,7 @@ class MeasurementSet(FileSet):
 class ConstructLibrary(FileSet):
     item_type = 'construct_library'
     schema = load_schema('igvfd:schemas/construct_library.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]

--- a/src/igvfd/types/lab.py
+++ b/src/igvfd/types/lab.py
@@ -3,6 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
+from snovault.util import Path
 from .base import (
     Item,
     paths_filtered_by_status,
@@ -23,6 +24,9 @@ class Lab(Item):
     item_type = 'lab'
     schema = load_schema('igvfd:schemas/lab.json')
     name_key = 'name'
+    embedded_with_frame = [
+        Path('awards', include=['@id', 'component']),
+    ]
 
     @calculated_property(
         schema={

--- a/src/igvfd/types/modification.py
+++ b/src/igvfd/types/modification.py
@@ -3,6 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
+from snovault.util import Path
 from .base import (
     Item
 )
@@ -18,6 +19,10 @@ from .base import (
 class Modification(Item):
     item_type = 'modification'
     schema = load_schema('igvfd:schemas/modification.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     @calculated_property(
         schema={

--- a/src/igvfd/types/phenotypic_feature.py
+++ b/src/igvfd/types/phenotypic_feature.py
@@ -3,6 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
+from snovault.util import Path
 from .base import (
     Item
 )
@@ -18,3 +19,7 @@ from .base import (
 class PhenotypicFeature(Item):
     item_type = 'phenotypic_feature'
     schema = load_schema('igvfd:schemas/phenotypic_feature.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]

--- a/src/igvfd/types/publication.py
+++ b/src/igvfd/types/publication.py
@@ -3,7 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
-
+from snovault.util import Path
 from .base import (
     Item,
     datetime
@@ -21,6 +21,10 @@ from .base import (
 class Publication(Item):
     item_type = 'publication'
     schema = load_schema('igvfd:schemas/publication.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     def unique_keys(self, properties):
         keys = super(Publication, self).unique_keys(properties)

--- a/src/igvfd/types/sample.py
+++ b/src/igvfd/types/sample.py
@@ -4,7 +4,7 @@ from snovault import (
     collection,
     load_schema,
 )
-
+from snovault.util import Path
 from .base import (
     Item,
     paths_filtered_by_status
@@ -133,6 +133,14 @@ class Biosample(Sample):
 class PrimaryCell(Biosample):
     item_type = 'primary_cell'
     schema = load_schema('igvfd:schemas/primary_cell.json')
+    embedded = ['treatments']
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('biosample_term', include=['@id', 'term_name']),
+        Path('disease_terms', include=['@id', 'term_name']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+    ]
 
 
 @collection(
@@ -145,6 +153,14 @@ class PrimaryCell(Biosample):
 class InVitroSystem(Biosample):
     item_type = 'in_vitro_system'
     schema = load_schema('igvfd:schemas/in_vitro_system.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('biosample_term', include=['@id', 'term_name']),
+        Path('disease_terms', include=['@id', 'term_name']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+        Path('treatments', include=['@id', 'treatment_term_name']),
+    ]
 
     @calculated_property(
         schema={
@@ -182,6 +198,13 @@ class InVitroSystem(Biosample):
 class Tissue(Biosample):
     item_type = 'tissue'
     schema = load_schema('igvfd:schemas/tissue.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('biosample_term', include=['@id', 'term_name']),
+        Path('disease_terms', include=['@id', 'term_name']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+    ]
 
 
 @collection(
@@ -195,6 +218,12 @@ class Tissue(Biosample):
 class TechnicalSample(Sample):
     item_type = 'technical_sample'
     schema = load_schema('igvfd:schemas/technical_sample.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'name', 'component']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+        Path('technical_sample_term', include=['@id', 'term_name']),
+    ]
 
     @calculated_property(
         schema={
@@ -220,6 +249,15 @@ class TechnicalSample(Sample):
 class WholeOrganism(Biosample):
     item_type = 'whole_organism'
     schema = load_schema('igvfd:schemas/whole_organism.json')
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('biomarkers', include=['@id', 'classification']),
+        Path('biosample_term', include=['@id', 'term_name']),
+        Path('disease_terms', include=['@id', 'term_name']),
+        Path('lab', include=['@id', 'title']),
+        Path('source', include=['@id', 'title']),
+        Path('treatments', include=['@id', 'treatment_type']),
+    ]
 
     @calculated_property(
         schema={

--- a/src/igvfd/types/software.py
+++ b/src/igvfd/types/software.py
@@ -3,6 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
+from snovault.util import Path
 from .base import (
     Item,
     paths_filtered_by_status
@@ -21,10 +22,9 @@ class Software(Item):
     item_type = 'software'
     schema = load_schema('igvfd:schemas/software.json')
     name_key = 'name'
-    embedded = [
-        'versions',
-        'lab',
-        'award'
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
     ]
     rev = {
         'versions': ('SoftwareVersion', 'software')

--- a/src/igvfd/types/software_version.py
+++ b/src/igvfd/types/software_version.py
@@ -3,6 +3,7 @@ from snovault import (
     collection,
     load_schema
 )
+from snovault.util import Path
 from .base import (
     Item
 )
@@ -23,7 +24,10 @@ from pyramid.traversal import (
 class SoftwareVersion(Item):
     item_type = 'software_version'
     schema = load_schema('igvfd:schemas/software_version.json')
-    embedded = ['software']
+    embedded_with_frame = [
+        Path('award', include=['@id', 'component']),
+        Path('lab', include=['@id', 'title']),
+    ]
 
     def unique_keys(self, properties):
         keys = super(SoftwareVersion, self).unique_keys(properties)

--- a/src/igvfd/types/treatment.py
+++ b/src/igvfd/types/treatment.py
@@ -3,6 +3,7 @@ from snovault import (
     load_schema,
     calculated_property
 )
+from snovault.util import Path
 from .base import (
     Item
 )
@@ -18,6 +19,9 @@ from .base import (
 class Treatment(Item):
     item_type = 'treatment'
     schema = load_schema('igvfd:schemas/treatment.json')
+    embedded_with_frame = [
+        Path('source', include=['@id', 'title']),
+    ]
 
     @calculated_property(
         schema={


### PR DESCRIPTION
I added `@id` to every slim embed because the report view uses embedded objects’ `@id` to link to those objects.

