### PR TITLE
IGVF-1002-fileset-search-config

### DIFF
--- a/src/igvfd/searches/configs/alignment_file.py
+++ b/src/igvfd/searches/configs/alignment_file.py
@@ -27,7 +27,10 @@ def alignment_file():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -43,6 +46,7 @@ def alignment_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {
@@ -77,12 +81,6 @@ def alignment_file():
             },
             'file_set': {
                 'title': 'File Set'
-            },
-            'assembly': {
-                'title': 'Assembly'
-            },
-            'transcriptome_annotation': {
-                'title': 'Transcriptome Annotation'
             },
             'reference_files': {
                 'title': 'Reference Files'

--- a/src/igvfd/searches/configs/analysis_set.py
+++ b/src/igvfd/searches/configs/analysis_set.py
@@ -22,6 +22,9 @@ def analysis_set():
             'status': {
                 'title': 'Status'
             },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -36,6 +39,7 @@ def analysis_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/assay_term.py
+++ b/src/igvfd/searches/configs/assay_term.py
@@ -22,6 +22,9 @@ def assay_term():
             'ontology': {
                 'title': 'Ontology'
             },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -30,13 +33,19 @@ def assay_term():
                     'assay_slims',
                     'category_slims',
                     'objective_slims',
-                ]
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
             },
             {
                 'title': 'Quality',
                 'facet_fields': [
                     'status',
-                ]
+                ],
             },
         ],
         'columns': {

--- a/src/igvfd/searches/configs/auxiliary_set.py
+++ b/src/igvfd/searches/configs/auxiliary_set.py
@@ -25,6 +25,9 @@ def auxiliary_set():
             'collections': {
                 'title': 'Collections',
             },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -40,6 +43,7 @@ def auxiliary_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/biosample.py
+++ b/src/igvfd/searches/configs/biosample.py
@@ -5,4 +5,52 @@ from snovault.elasticsearch.searches.configs import search_config
     name='Biosample'
 )
 def biosample():
-    return {}
+    return {
+        'facets': {
+            'classification': {
+                'title': 'Classification',
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'virtual': {
+                'title': 'Virtual'
+            },
+            'type': {
+                'title': 'Object Type'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'classification',
+                    'virtual',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'type',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
+    }

--- a/src/igvfd/searches/configs/configuration_file.py
+++ b/src/igvfd/searches/configs/configuration_file.py
@@ -27,7 +27,10 @@ def configuration_file():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Type'
+            },
         },
         'facet_groups': [
             {
@@ -43,6 +46,7 @@ def configuration_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/construct_library_set.py
+++ b/src/igvfd/searches/configs/construct_library_set.py
@@ -27,7 +27,10 @@ def construct_library_set():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -44,6 +47,7 @@ def construct_library_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/curated_set.py
+++ b/src/igvfd/searches/configs/curated_set.py
@@ -24,7 +24,10 @@ def curated_set():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -40,6 +43,7 @@ def curated_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/donor.py
+++ b/src/igvfd/searches/configs/donor.py
@@ -5,4 +5,99 @@ from snovault.elasticsearch.searches.configs import search_config
     name='Donor'
 )
 def donor():
-    return {}
+    return {
+        'facets': {
+            'sex': {
+                'title': 'Sex'
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'virtual': {
+                'title': 'Virtual'
+            },
+            'type': {
+                'title': 'Object Type',
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Donor',
+                'facet_fields': [
+                    'sex',
+                    'virtual',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'type',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
+        'columns': {
+            'uuid': {
+                'title': 'UUID'
+            },
+            'accession': {
+                'title': 'Accession'
+            },
+            'alternate_accessions': {
+                'title': 'Alternate Accessions'
+            },
+            'aliases': {
+                'title': 'Aliases'
+            },
+            'taxa': {
+                'title': 'Taxa'
+            },
+            'sex': {
+                'title': 'Sex'
+            },
+            'award': {
+                'title': 'Award'
+            },
+            'ethnicities': {
+                'title': 'Ethnicities'
+            },
+            'human_donor_identifiers': {
+                'title': 'Human Donor Identifiers'
+            },
+            'lab': {
+                'title': 'Lab'
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'submitted_by': {
+                'title': 'Submitted By'
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'phenotypic_features': {
+                'title': 'Phenotypic Features'
+            },
+            'virtual': {
+                'title': 'Virtual'
+            }
+        }
+    }

--- a/src/igvfd/searches/configs/file.py
+++ b/src/igvfd/searches/configs/file.py
@@ -5,4 +5,56 @@ from snovault.elasticsearch.searches.configs import search_config
     name='File'
 )
 def file():
-    return {}
+    return {
+        'facets': {
+            'award.component': {
+                'title': 'Award',
+            },
+            'collections': {
+                'title': 'Collections'
+            },
+            'content_type': {
+                'title': 'Content Type'
+            },
+            'file_format': {
+                'title': 'File Format'
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'upload_status': {
+                'title': 'Upload Status'
+            },
+            'type': {
+                'title': 'Object Type'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Format',
+                'facet_fields': [
+                    'file_format',
+                    'content_type',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'upload_status',
+                    'status',
+                ],
+            },
+        ]
+    }

--- a/src/igvfd/searches/configs/file_set.py
+++ b/src/igvfd/searches/configs/file_set.py
@@ -5,4 +5,48 @@ from snovault.elasticsearch.searches.configs import search_config
     name='FileSet'
 )
 def file_set():
-    return {}
+    return {
+        'facets': {
+            'collections': {
+                'title': 'Collections',
+            },
+            'donors.taxa': {
+                'title': 'Taxa',
+            },
+            'lab.title': {
+                'title': 'Lab'
+            },
+            'award.component': {
+                'title': 'Award'
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'type': {
+                'title': 'Object Type',
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'File Set',
+                'facet_fields': [
+                    'donors.taxa',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ]
+    }

--- a/src/igvfd/searches/configs/human_donor.py
+++ b/src/igvfd/searches/configs/human_donor.py
@@ -27,7 +27,10 @@ def human_donor():
             },
             'virtual': {
                 'title': 'Virtual'
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -44,6 +47,7 @@ def human_donor():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/human_genomic_variant.py
+++ b/src/igvfd/searches/configs/human_genomic_variant.py
@@ -7,13 +7,44 @@ from snovault.elasticsearch.searches.configs import search_config
 def human_genomic_variant():
     return {
         'facets': {
+            'alt': {
+                'title': 'Alternative Allele',
+            },
             'assembly': {
                 'title': 'Genome Assembly'
+            },
+            'ref': {
+                'title': 'Reference Allele',
             },
             'status': {
                 'title': 'Status'
             },
+            'type': {
+                'title': 'Object Type',
+            },
         },
+        'facet_groups': [
+            {
+                'title': 'Variant',
+                'facet_fields': [
+                    'assembly',
+                    'alt',
+                    'ref',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/in_vitro_system.py
+++ b/src/igvfd/searches/configs/in_vitro_system.py
@@ -45,7 +45,10 @@ def in_vitro_system():
             },
             'biomarkers.classification': {
                 'title': 'Biomarkers Classification'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -68,6 +71,7 @@ def in_vitro_system():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/matrix_file.py
+++ b/src/igvfd/searches/configs/matrix_file.py
@@ -51,6 +51,7 @@ def matrix_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/measurement_set.py
+++ b/src/igvfd/searches/configs/measurement_set.py
@@ -25,6 +25,9 @@ def measurement_set():
             'status': {
                 'title': 'Status'
             },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -40,6 +43,7 @@ def measurement_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/model_set.py
+++ b/src/igvfd/searches/configs/model_set.py
@@ -24,7 +24,10 @@ def model_set():
             },
             'prediction_objects': {
                 'title': 'Prediction Objects'
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -40,6 +43,7 @@ def model_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/multiplexed_sample.py
+++ b/src/igvfd/searches/configs/multiplexed_sample.py
@@ -36,7 +36,10 @@ def multiplexed_sample():
             },
             'virtual': {
                 'title': 'Virtual'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -56,6 +59,7 @@ def multiplexed_sample():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/ontology_term.py
+++ b/src/igvfd/searches/configs/ontology_term.py
@@ -5,4 +5,55 @@ from snovault.elasticsearch.searches.configs import search_config
     name='OntologyTerm'
 )
 def ontology_term():
-    return {}
+    return {
+        'facets': {
+            'ontology': {
+                'title': 'Ontology'
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'type': {
+                'title': 'Object Type',
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Assay',
+                'facet_fields': [
+                    'assay_slims',
+                    'category_slims',
+                    'objective_slims',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
+        'columns': {
+            'uuid': {
+                'title': 'UUID'
+            },
+            'term_id': {
+                'title': 'Term ID'
+            },
+            'term_name': {
+                'title': 'Term Name'
+            },
+            'synonyms': {
+                'title': 'Synonyms'
+            },
+            'status': {
+                'title': 'Status'
+            }
+        }
+    }

--- a/src/igvfd/searches/configs/phenotype_term.py
+++ b/src/igvfd/searches/configs/phenotype_term.py
@@ -7,13 +7,40 @@ from snovault.elasticsearch.searches.configs import search_config
 def phenotype_term():
     return {
         'facets': {
+            'ontology': {
+                'title': 'Ontology'
+            },
             'status': {
                 'title': 'Status'
             },
-            'ontology': {
-                'title': 'Ontology'
-            }
+            'term_id': {
+                'title': 'Term ID'
+            },
+            'term_name': {
+                'title': 'Term Name'
+            },
         },
+        'facet_groups': [
+            {
+                'title': 'Phenotype',
+                'facet_fields': [
+                    'term_id',
+                    'term_name',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/platform_term.py
+++ b/src/igvfd/searches/configs/platform_term.py
@@ -7,13 +7,43 @@ from snovault.elasticsearch.searches.configs import search_config
 def platform_term():
     return {
         'facets': {
-            'status': {
-                'title': 'Status'
-            },
             'ontology': {
                 'title': 'Ontology'
             },
+            'status': {
+                'title': 'Status'
+            },
+            'term_id': {
+                'title': 'Term ID'
+            },
+            'term_name': {
+                'title': 'Term Name'
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
+        'facet_groups': [
+            {
+                'title': 'Platform',
+                'facet_fields': [
+                    'term_id',
+                    'term_name',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
         'columns': {
             'uuid': {
                 'title': 'UUID'

--- a/src/igvfd/searches/configs/prediction_set.py
+++ b/src/igvfd/searches/configs/prediction_set.py
@@ -24,7 +24,10 @@ def prediction_set():
             },
             'donors.taxa': {
                 'title': 'Taxa',
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -40,6 +43,7 @@ def prediction_set():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/primary_cell.py
+++ b/src/igvfd/searches/configs/primary_cell.py
@@ -42,7 +42,10 @@ def primary_cell():
             },
             'biomarkers.classification': {
                 'title': 'Biomarkers Classification'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -64,6 +67,7 @@ def primary_cell():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/reference_file.py
+++ b/src/igvfd/searches/configs/reference_file.py
@@ -30,7 +30,10 @@ def reference_file():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Type'
+            },
         },
         'facet_groups': [
             {
@@ -52,6 +55,7 @@ def reference_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/rodent_donor.py
+++ b/src/igvfd/searches/configs/rodent_donor.py
@@ -30,7 +30,10 @@ def rodent_donor():
             },
             'virtual': {
                 'title': 'Virtual'
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -48,6 +51,7 @@ def rodent_donor():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/sample.py
+++ b/src/igvfd/searches/configs/sample.py
@@ -5,4 +5,52 @@ from snovault.elasticsearch.searches.configs import search_config
     name='Sample'
 )
 def sample():
-    return {}
+    return {
+        'facets': {
+            'classification': {
+                'title': 'Classification',
+            },
+            'collections': {
+                'title': 'Collections',
+            },
+            'lab.title': {
+                'title': 'Lab',
+            },
+            'award.component': {
+                'title': 'Award',
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'virtual': {
+                'title': 'Virtual'
+            },
+            'type': {
+                'title': 'Object Type'
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Sample',
+                'facet_fields': [
+                    'classification',
+                    'virtual',
+                ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'collections',
+                    'lab.title',
+                    'award.component',
+                    'type',
+                ]
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ]
+            },
+        ],
+    }

--- a/src/igvfd/searches/configs/sample_term.py
+++ b/src/igvfd/searches/configs/sample_term.py
@@ -24,7 +24,10 @@ def sample_term():
             },
             'ontology': {
                 'title': 'Ontology'
-            }
+            },
+            'type': {
+                'title': 'Object Type',
+            },
         },
         'facet_groups': [
             {
@@ -35,6 +38,12 @@ def sample_term():
                     'developmental_slims',
                     'system_slims',
                 ]
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
             },
             {
                 'title': 'Quality',

--- a/src/igvfd/searches/configs/sequence_file.py
+++ b/src/igvfd/searches/configs/sequence_file.py
@@ -30,7 +30,10 @@ def sequence_file():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Type'
+            },
         },
         'facet_groups': [
             {
@@ -47,6 +50,7 @@ def sequence_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/signal_file.py
+++ b/src/igvfd/searches/configs/signal_file.py
@@ -30,7 +30,10 @@ def signal_file():
             },
             'status': {
                 'title': 'Status'
-            }
+            },
+            'type': {
+                'title': 'Type'
+            },
         },
         'facet_groups': [
             {
@@ -47,6 +50,7 @@ def signal_file():
                     'collections',
                     'lab.title',
                     'award.component',
+                    'type',
                 ],
             },
             {

--- a/src/igvfd/searches/configs/technical_sample.py
+++ b/src/igvfd/searches/configs/technical_sample.py
@@ -27,7 +27,10 @@ def technical_sample():
             },
             'virtual': {
                 'title': 'Virtual'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -44,6 +47,7 @@ def technical_sample():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/tissue.py
+++ b/src/igvfd/searches/configs/tissue.py
@@ -42,7 +42,10 @@ def tissue():
             },
             'biomarkers.classification': {
                 'title': 'Biomarkers Classification'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -64,6 +67,7 @@ def tissue():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/searches/configs/variant.py
+++ b/src/igvfd/searches/configs/variant.py
@@ -5,4 +5,44 @@ from snovault.elasticsearch.searches.configs import search_config
     name='Variant'
 )
 def variant():
-    return {}
+    return {
+        'facets': {
+            'alt': {
+                'title': 'Alternative Allele',
+            },
+            'assembly': {
+                'title': 'Genome Assembly'
+            },
+            'ref': {
+                'title': 'Reference Allele',
+            },
+            'status': {
+                'title': 'Status'
+            },
+            'type': {
+                'title': 'Object Type',
+            },
+        },
+        'facet_groups': [
+            {
+                'title': 'Variant',
+                'facet_fields': [
+                    'assembly',
+                    'alt',
+                    'ref',
+                ],
+            },
+            {
+                'title': 'Provenance',
+                'facet_fields': [
+                    'type',
+                ],
+            },
+            {
+                'title': 'Quality',
+                'facet_fields': [
+                    'status',
+                ],
+            },
+        ],
+    }

--- a/src/igvfd/searches/configs/whole_organism.py
+++ b/src/igvfd/searches/configs/whole_organism.py
@@ -39,7 +39,10 @@ def whole_organism():
             },
             'virtual': {
                 'title': 'Virtual'
-            }
+            },
+            'type': {
+                'title': 'Object Type'
+            },
         },
         'facet_groups': [
             {
@@ -60,6 +63,7 @@ def whole_organism():
                     'lab.title',
                     'award.component',
                     'sources.title',
+                    'type',
                 ]
             },
             {

--- a/src/igvfd/tests/indexing/test_report_tsv.py
+++ b/src/igvfd/tests/indexing/test_report_tsv.py
@@ -72,7 +72,7 @@ def test_multitype_report_download(workbook, testapp):
     lines = res.body.splitlines()
     assert b'/multireport/' in lines[0]
     assert lines[1].split(b'\t') == [
-        b'ID', b'UUID', b'Accession', b'Alternate Accessions', b'Content Type', b'File Format', b'Lab', b'Status', b'File Set', b'Illumina Read Type', b'External Identifiers', b'Upload Status', b'Assembly', b'Transcriptome Annotation', b'Reference Files', b'Content Summary', b'Seqspec Of'
+        b'ID', b'UUID', b'Accession', b'Alternate Accessions', b'Content Type', b'File Format', b'Lab', b'Status', b'File Set', b'Illumina Read Type', b'External Identifiers', b'Upload Status', b'Reference Files', b'Content Summary', b'Assembly', b'Transcriptome Annotation', b'Seqspec Of'
     ]
 
     res = testapp.get('/multireport.tsv?type=SequenceFile&type=AlignmentFile&status=released')
@@ -82,5 +82,5 @@ def test_multitype_report_download(workbook, testapp):
     lines = res.body.splitlines()
     assert b'/multireport/' in lines[0]
     assert lines[1].split(b'\t') == [
-        b'ID', b'UUID', b'Accession', b'Alternate Accessions', b'Content Type', b'File Format', b'Lab', b'Status', b'File Set', b'Illumina Read Type', b'External Identifiers', b'Upload Status', b'Assembly', b'Transcriptome Annotation', b'Reference Files', b'Content Summary'
+        b'ID', b'UUID', b'Accession', b'Alternate Accessions', b'Content Type', b'File Format', b'Lab', b'Status', b'File Set', b'Illumina Read Type', b'External Identifiers', b'Upload Status', b'Reference Files', b'Content Summary'
     ]


### PR DESCRIPTION
This mostly involves adding a search config to abstract types, and adding a `type` property to these search configs as well as their child search configs.

I removed the `assembly` and `transcriptome_annotation` properties from the AlignmentFile search config because these properties don’t exist in AlignmentFile objects anymore.