### PR TITLE
IGVF-1127-embed-construct-library-sets

### DIFF
--- a/src/igvfd/types/sample.py
+++ b/src/igvfd/types/sample.py
@@ -476,7 +476,7 @@ class MultiplexedSample(Sample):
         Path('sample_terms', include=['@id', 'term_name']),
         Path('disease_terms', include=['@id', 'term_name']),
         Path('multiplexed_samples', include=['@id', 'accession', '@type',
-             'summary', 'sample_terms', 'disease_terms', 'donors', 'status']),
+             'summary', 'sample_terms', 'construct_library_sets', 'disease_terms', 'donors', 'status']),
         Path('multiplexed_samples.sample_terms', include=['term_name']),
         Path('multiplexed_samples.disease_terms', include=['term_name']),
         Path('multiplexed_samples.donors', include=['@id', 'accession']),


### PR DESCRIPTION
embedding construct_library_sets property for the constituent samples of MultiplexedSample

For https://igvf.atlassian.net/browse/IGVF-1127

Required for https://github.com/IGVF-DACC/igvf-ui/pull/328
