### PR TITLE
IGVF-1243-add-full-download-url-to-report

### DIFF
--- a/src/igvfd/report.py
+++ b/src/igvfd/report.py
@@ -53,7 +53,7 @@ def format_row(columns):
     return b'\t'.join([bytes_(' '.join(c.strip('\t\n\r').split()), 'utf-8') for c in columns]) + b'\r\n'
 
 
-def format_row_full_url(columns, href_index, host_url):
+def format_row_full_url(columns, href_index, host_url, id):
     """Format a list of text columns as a tab-separated byte string. add host_url to href to form a full length url"""
     row = []
     for index, column in enumerate(columns):
@@ -61,7 +61,12 @@ def format_row_full_url(columns, href_index, host_url):
         if index == href_index:
             # href is not embedded, append host_url directly
             if len(ls) == 1:
-                ls[0] = host_url + ls[0]
+                # attachment.href
+                if ls[0].startswith('@@download'):
+                    ls[0] = host_url + id + ls[0]
+                # href from File
+                else:
+                    ls[0] = host_url + ls[0]
             # href is embedded
             else:
                 for index, item in enumerate(ls):
@@ -69,7 +74,7 @@ def format_row_full_url(columns, href_index, host_url):
                         embedded_index = index + 1
                         break
                 if embedded_index:
-                    ls[embedded_index] = ls[embedded_index][0] + host_url + ls[embedded_index][1:]
+                    ls[embedded_index] = ls[embedded_index][0] + host_url + id + ls[embedded_index][1:]
 
         row.append(bytes_(' '.join(ls), 'utf-8'))
     return b'\t'.join(row) + b'\r\n'

--- a/src/igvfd/report.py
+++ b/src/igvfd/report.py
@@ -68,7 +68,7 @@ def format_row_full_url(columns, href_index, host_url, id):
                 else:
                     ls[0] = host_url + ls[0]
             # href is embedded
-            else:
+            elif len(ls) > 1:
                 for index, item in enumerate(ls):
                     if ''.join([i for i in item if i.isalpha()]) == 'href':
                         embedded_index = index + 1

--- a/src/igvfd/report.py
+++ b/src/igvfd/report.py
@@ -217,8 +217,9 @@ def multitype_report_download(context, request):
         yield format_header()
         yield format_row(header_row)
         for item in results['@graph']:
+            id = item['@id']
             values = [lookup_column_value(item, path) for path in columns]
-            yield format_row_full_url(values, href_index, request.host_url)
+            yield format_row_full_url(values, href_index, request.host_url, id)
 
     # Stream response using chunked encoding.
     request.response.content_type = 'text/tsv'

--- a/src/igvfd/report.py
+++ b/src/igvfd/report.py
@@ -10,9 +10,7 @@ from igvfd.searches.generator import search_generator
 import datetime
 import re
 
-# Doncument.attachment and Image.attachment have href
-TYPES_WITH_HREF_FEILD = ['ReferenceFile', 'SequenceFile', 'AlignmentFile', 'GenomeBrowserAnnotationFile',
-                         'MatrixFile', 'SignalFile', 'TabularFile', 'ConfigurationFile', 'Document', 'Image']
+# Those columns contain href value
 HREF_COLUMN_KEYS = ['href', 'attachment', 'attachment.href']
 
 
@@ -61,7 +59,7 @@ def format_row_full_url(columns, href_index, host_url):
     for index, column in enumerate(columns):
         ls = column.strip('\t\n\r').split()
         if index == href_index:
-
+            # href is not embedded, append host_url directly
             if len(ls) == 1:
                 ls[0] = host_url + ls[0]
             # href is embedded
@@ -191,10 +189,6 @@ def multitype_report_download(context, request):
     if len(types_in_search_result) == 1:
         report_type = _convert_camel_to_snake(types_in_search_result[0]).replace("'", '')
 
-    print('types_in_search_result:', types_in_search_result)
-    print('request.host_url:', request.host_url)
-    print('columns:', columns)
-
     # Make sure we get all results
     request.GET['limit'] = 'all'
     results = search_generator(request)
@@ -208,8 +202,6 @@ def multitype_report_download(context, request):
         columns['@id']['title'] = 'id'
 
     header_row = [column.get('title') or field for field, column in columns.items()]
-    print('header_row:', header_row)
-
     columns_keys = list(columns.keys())
     href_index = -1
     for index, item in enumerate(columns_keys):
@@ -221,8 +213,6 @@ def multitype_report_download(context, request):
         yield format_row(header_row)
         for item in results['@graph']:
             values = [lookup_column_value(item, path) for path in columns]
-            print('values!!!!!!!!!!!!!!!!:', values)
-
             yield format_row_full_url(values, href_index, request.host_url)
 
     # Stream response using chunked encoding.

--- a/src/igvfd/report.py
+++ b/src/igvfd/report.py
@@ -58,7 +58,7 @@ def format_row_full_url(columns, href_index, host_url, id):
     row = []
     for index, column in enumerate(columns):
         ls = column.strip('\t\n\r').split()
-        if index == href_index:
+        if index in href_index:
             # href is not embedded, append host_url directly
             if len(ls) == 1:
                 # attachment.href
@@ -208,10 +208,10 @@ def multitype_report_download(context, request):
 
     header_row = [column.get('title') or field for field, column in columns.items()]
     columns_keys = list(columns.keys())
-    href_index = -1
+    href_index = []
     for index, item in enumerate(columns_keys):
         if item in HREF_COLUMN_KEYS:
-            href_index = index
+            href_index.append(index)
 
     def generate_rows():
         yield format_header()

--- a/src/igvfd/tests/indexing/test_report_tsv.py
+++ b/src/igvfd/tests/indexing/test_report_tsv.py
@@ -93,16 +93,21 @@ def test_multitype_report_download_href(workbook, testapp):
     server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
     assert lines[2].startswith(server_url)
 
-    res = testapp.get('/multireport.tsv?type=Image&field=%40id&field=attachment')
-    lines = res.text.splitlines()
-    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
-    id = lines[2].split('\t')[1]
-    full_href = server_url + id + '@@download/attachment/h3k4me3_millipore_07-473_lot_DAM1651667_WB.png'
-    assert lines[2][1] == full_href
-
     res = testapp.get('/multireport.tsv?type=Image&field=%40id&field=attachment.href')
     lines = res.text.splitlines()
     server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
-    id = lines[2].split('\t')[1]
+    id = lines[2].split('\t')[0]
     full_href = server_url + id + '@@download/attachment/h3k4me3_millipore_07-473_lot_DAM1651667_WB.png'
-    assert lines[2][1] == full_href
+    assert lines[2].split('\t')[1] == full_href
+
+    res = testapp.get('/multireport.tsv?type=Image&field=%40id&field=attachment')
+    lines = res.text.splitlines()
+    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
+    id = lines[2].split('\t')[0]
+    full_href = server_url + id + '@@download/attachment/h3k4me3_millipore_07-473_lot_DAM1651667_WB.png'
+    assert full_href in lines[2].split('\t')[1]
+
+    res = testapp.get('/multireport.tsv?type=Lab&field=href')
+    lines = res.text.splitlines()
+    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
+    assert lines[2] == ''

--- a/src/igvfd/tests/indexing/test_report_tsv.py
+++ b/src/igvfd/tests/indexing/test_report_tsv.py
@@ -109,5 +109,4 @@ def test_multitype_report_download_href(workbook, testapp):
 
     res = testapp.get('/multireport.tsv?type=Lab&field=href')
     lines = res.text.splitlines()
-    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
     assert lines[2] == ''

--- a/src/igvfd/tests/indexing/test_report_tsv.py
+++ b/src/igvfd/tests/indexing/test_report_tsv.py
@@ -33,7 +33,7 @@ def test_batch_download_human_donor_report_download(workbook, testapp):
     assert disposition.startswith('attachment;filename="human_donor_report') and disposition.endswith('.tsv"')
 
 
-def test_multitype_report_download(workbook, testapp):
+def test_multitype_report_download_no_href(workbook, testapp):
 
     res = testapp.get('/multireport.tsv?institute_label=Stanford')
     assert res.headers['content-type'] == 'text/tsv; charset=UTF-8'
@@ -84,3 +84,25 @@ def test_multitype_report_download(workbook, testapp):
     assert lines[1].split(b'\t') == [
         b'ID', b'UUID', b'Accession', b'Alternate Accessions', b'Content Type', b'File Format', b'Lab', b'Status', b'File Set', b'Illumina Read Type', b'External Identifiers', b'Upload Status', b'Reference Files', b'Content Summary'
     ]
+
+
+def test_multitype_report_download_href(workbook, testapp):
+
+    res = testapp.get('/multireport.tsv?type=File&field=href')
+    lines = res.text.splitlines()
+    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
+    assert lines[2].startswith(server_url)
+
+    res = testapp.get('/multireport.tsv?type=Image&field=%40id&field=attachment')
+    lines = res.text.splitlines()
+    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
+    id = lines[2].split('\t')[1]
+    full_href = server_url + id + '@@download/attachment/h3k4me3_millipore_07-473_lot_DAM1651667_WB.png'
+    assert lines[2][1] == full_href
+
+    res = testapp.get('/multireport.tsv?type=Image&field=%40id&field=attachment.href')
+    lines = res.text.splitlines()
+    server_url = res.headers['X-Request-URL'].split('/multireport.tsv?')[0]
+    id = lines[2].split('\t')[1]
+    full_href = server_url + id + '@@download/attachment/h3k4me3_millipore_07-473_lot_DAM1651667_WB.png'
+    assert lines[2][1] == full_href


### PR DESCRIPTION
There types: File, Document and Image has href. For Document and Image, href is embedded in attachment. What I did in this ticket is to complete the href to make a full length URL in downloaded report.