### PR TITLE
IGVF-1344-embed-fileset-construct

### DIFF
--- a/src/igvfd/mappings/measurement_set.json
+++ b/src/igvfd/mappings/measurement_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "4ff07a9192f27e9172a9669ae08d8b86",
-    "index_name": "measurement_set_4ff07a91",
+    "hash": "8658f881f2cf619ac12e6bed34adb152",
+    "index_name": "measurement_set_8658f881",
     "item_type": "measurement_set",
     "mapping": {
         "dynamic_templates": [
@@ -2087,7 +2087,223 @@
                                 "type": "keyword"
                             },
                             "construct_library_sets": {
-                                "type": "keyword"
+                                "properties": {
+                                    "@id": {
+                                        "type": "keyword"
+                                    },
+                                    "@type": {
+                                        "type": "keyword"
+                                    },
+                                    "accession": {
+                                        "type": "keyword"
+                                    },
+                                    "aliases": {
+                                        "type": "keyword"
+                                    },
+                                    "alternate_accessions": {
+                                        "type": "keyword"
+                                    },
+                                    "applied_to_samples": {
+                                        "type": "keyword"
+                                    },
+                                    "associated_phenotypes": {
+                                        "type": "keyword"
+                                    },
+                                    "average_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "float"
+                                    },
+                                    "average_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "float"
+                                    },
+                                    "award": {
+                                        "type": "keyword"
+                                    },
+                                    "collections": {
+                                        "type": "keyword"
+                                    },
+                                    "control_for": {
+                                        "type": "keyword"
+                                    },
+                                    "creation_timestamp": {
+                                        "type": "keyword"
+                                    },
+                                    "description": {
+                                        "type": "text"
+                                    },
+                                    "documents": {
+                                        "type": "keyword"
+                                    },
+                                    "exon": {
+                                        "type": "keyword"
+                                    },
+                                    "file_set_type": {
+                                        "type": "keyword"
+                                    },
+                                    "files": {
+                                        "type": "keyword"
+                                    },
+                                    "genes": {
+                                        "type": "keyword"
+                                    },
+                                    "guide_type": {
+                                        "type": "keyword"
+                                    },
+                                    "integrated_content_files": {
+                                        "type": "keyword"
+                                    },
+                                    "lab": {
+                                        "type": "keyword"
+                                    },
+                                    "loci": {
+                                        "properties": {
+                                            "assembly": {
+                                                "type": "keyword"
+                                            },
+                                            "chromosome": {
+                                                "type": "keyword"
+                                            },
+                                            "end": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            },
+                                            "start": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "lot_id": {
+                                        "type": "keyword"
+                                    },
+                                    "lower_bound_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "lower_bound_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "notes": {
+                                        "type": "text"
+                                    },
+                                    "product_id": {
+                                        "type": "keyword"
+                                    },
+                                    "publication_identifiers": {
+                                        "type": "keyword"
+                                    },
+                                    "revoke_detail": {
+                                        "type": "keyword"
+                                    },
+                                    "schema_version": {
+                                        "type": "keyword"
+                                    },
+                                    "scope": {
+                                        "type": "keyword"
+                                    },
+                                    "selection_criteria": {
+                                        "type": "keyword"
+                                    },
+                                    "sources": {
+                                        "type": "keyword"
+                                    },
+                                    "status": {
+                                        "type": "keyword"
+                                    },
+                                    "submitted_by": {
+                                        "type": "keyword"
+                                    },
+                                    "submitter_comment": {
+                                        "type": "keyword"
+                                    },
+                                    "summary": {
+                                        "type": "keyword"
+                                    },
+                                    "tile": {
+                                        "properties": {
+                                            "tile_end": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            },
+                                            "tile_id": {
+                                                "type": "keyword"
+                                            },
+                                            "tile_start": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "tiling_modality": {
+                                        "type": "keyword"
+                                    },
+                                    "upper_bound_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "upper_bound_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "uuid": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "type": "object"
                             },
                             "creation_timestamp": {
                                 "type": "keyword"

--- a/src/igvfd/mappings/prediction_set.json
+++ b/src/igvfd/mappings/prediction_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "989cea0cc3c9600406f73e774cc1ce12",
-    "index_name": "prediction_set_989cea0c",
+    "hash": "08791b8ebdd6e7c2b051940b3823e680",
+    "index_name": "prediction_set_08791b8e",
     "item_type": "prediction_set",
     "mapping": {
         "dynamic_templates": [
@@ -1166,7 +1166,223 @@
                                 "type": "keyword"
                             },
                             "construct_library_sets": {
-                                "type": "keyword"
+                                "properties": {
+                                    "@id": {
+                                        "type": "keyword"
+                                    },
+                                    "@type": {
+                                        "type": "keyword"
+                                    },
+                                    "accession": {
+                                        "type": "keyword"
+                                    },
+                                    "aliases": {
+                                        "type": "keyword"
+                                    },
+                                    "alternate_accessions": {
+                                        "type": "keyword"
+                                    },
+                                    "applied_to_samples": {
+                                        "type": "keyword"
+                                    },
+                                    "associated_phenotypes": {
+                                        "type": "keyword"
+                                    },
+                                    "average_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "float"
+                                    },
+                                    "average_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "float"
+                                    },
+                                    "award": {
+                                        "type": "keyword"
+                                    },
+                                    "collections": {
+                                        "type": "keyword"
+                                    },
+                                    "control_for": {
+                                        "type": "keyword"
+                                    },
+                                    "creation_timestamp": {
+                                        "type": "keyword"
+                                    },
+                                    "description": {
+                                        "type": "text"
+                                    },
+                                    "documents": {
+                                        "type": "keyword"
+                                    },
+                                    "exon": {
+                                        "type": "keyword"
+                                    },
+                                    "file_set_type": {
+                                        "type": "keyword"
+                                    },
+                                    "files": {
+                                        "type": "keyword"
+                                    },
+                                    "genes": {
+                                        "type": "keyword"
+                                    },
+                                    "guide_type": {
+                                        "type": "keyword"
+                                    },
+                                    "integrated_content_files": {
+                                        "type": "keyword"
+                                    },
+                                    "lab": {
+                                        "type": "keyword"
+                                    },
+                                    "loci": {
+                                        "properties": {
+                                            "assembly": {
+                                                "type": "keyword"
+                                            },
+                                            "chromosome": {
+                                                "type": "keyword"
+                                            },
+                                            "end": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            },
+                                            "start": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "lot_id": {
+                                        "type": "keyword"
+                                    },
+                                    "lower_bound_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "lower_bound_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "notes": {
+                                        "type": "text"
+                                    },
+                                    "product_id": {
+                                        "type": "keyword"
+                                    },
+                                    "publication_identifiers": {
+                                        "type": "keyword"
+                                    },
+                                    "revoke_detail": {
+                                        "type": "keyword"
+                                    },
+                                    "schema_version": {
+                                        "type": "keyword"
+                                    },
+                                    "scope": {
+                                        "type": "keyword"
+                                    },
+                                    "selection_criteria": {
+                                        "type": "keyword"
+                                    },
+                                    "sources": {
+                                        "type": "keyword"
+                                    },
+                                    "status": {
+                                        "type": "keyword"
+                                    },
+                                    "submitted_by": {
+                                        "type": "keyword"
+                                    },
+                                    "submitter_comment": {
+                                        "type": "keyword"
+                                    },
+                                    "summary": {
+                                        "type": "keyword"
+                                    },
+                                    "tile": {
+                                        "properties": {
+                                            "tile_end": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            },
+                                            "tile_id": {
+                                                "type": "keyword"
+                                            },
+                                            "tile_start": {
+                                                "fields": {
+                                                    "raw": {
+                                                        "type": "keyword"
+                                                    }
+                                                },
+                                                "store": true,
+                                                "type": "long"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "tiling_modality": {
+                                        "type": "keyword"
+                                    },
+                                    "upper_bound_guide_coverage": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "upper_bound_insert_size": {
+                                        "fields": {
+                                            "raw": {
+                                                "type": "keyword"
+                                            }
+                                        },
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "uuid": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "type": "object"
                             },
                             "creation_timestamp": {
                                 "type": "keyword"

--- a/src/igvfd/types/file_set.py
+++ b/src/igvfd/types/file_set.py
@@ -44,8 +44,22 @@ class FileSet(Item):
              'file_format', 'file_size', 'href', 's3_uri', 'submitted_file_name']),
         Path('control_for', include=['@id', 'accession', 'aliases']),
         Path('donors', include=['@id', 'accession', 'aliases', 'taxa']),
-        Path('samples.sample_terms', include=['@id', 'accession', 'aliases', 'treatments', 'cell_fate_change_treatments',
-             'classification', 'disease_terms', 'modifications', 'sample_terms', 'summary', 'targeted_sample_term', 'taxa', 'term_name']),
+        Path('samples.sample_terms', include=[
+            '@id',
+            'accession',
+            'aliases',
+            'treatments',
+            'cell_fate_change_treatments',
+            'classification',
+            'construct_library_sets',
+            'disease_terms',
+            'modifications',
+            'sample_terms',
+            'summary',
+            'targeted_sample_term',
+            'taxa',
+            'term_name',
+        ]),
         Path('samples.targeted_sample_term', include=['@id', 'term_name']),
     ]
 
@@ -254,6 +268,7 @@ class MeasurementSet(FileSet):
         Path('samples.cell_fate_change_treatments', include=['@id', 'purpose', 'treatment_type', 'summary']),
         Path('samples.disease_terms', include=['@id', 'term_name']),
         Path('samples.modifications', include=['@id', 'modality']),
+        Path('samples.construct_library_sets', include=['@id', 'accession', 'summary']),
     ]
 
     audit_inherit = FileSet.audit_inherit + [
@@ -460,7 +475,9 @@ class AuxiliarySet(FileSet):
 class PredictionSet(FileSet):
     item_type = 'prediction_set'
     schema = load_schema('igvfd:schemas/prediction_set.json')
-    embedded_with_frame = FileSet.embedded_with_frame
+    embedded_with_frame = FileSet.embedded_with_frame + [
+        Path('samples.construct_library_sets', include=['@id', 'accession', 'summary']),
+    ]
     audit_inherit = FileSet.audit_inherit
 
 


### PR DESCRIPTION
I need this for [IGVF-1079](https://igvf.atlassian.net/browse/IGVF-1079) so that we can more efficiently retrieve the construct libraries associated with the sample objects associated with MeasurementSet or PredictionSet.

[IGVF-1079]: https://igvf.atlassian.net/browse/IGVF-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ