### PR TITLE
bump-sqlitedict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     rfc3987==1.3.8
     rutter==1.0
     subprocess_middleware==0.3
-    sqlitedict==2.0.0
+    sqlitedict==2.1.0
     transaction==3.0.0
     waitress==1.4.3
     xlrd==1.2.0


### PR DESCRIPTION
Fix pytest deprecation warning: 
```
 /opt/venv/lib/python3.11/site-packages/sqlitedict.py:381: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
igvfd-pyramid-1     |     self.setDaemon(True)  # python2.5-compatible
```