### PR TITLE
remove-return-from-test

### DIFF
--- a/src/igvfd/tests/test_schema_phenotypic_feature.py
+++ b/src/igvfd/tests/test_schema_phenotypic_feature.py
@@ -8,7 +8,7 @@ def test_phenotypic_feature_required_lab_award(
     item = {
         'feature': phenotype_term_ncit_feature['@id']
     }
-    testapp.post_json('/phenotypic_feature', item, expect_errors=True)
+    res = testapp.post_json('/phenotypic_feature', item, expect_errors=True)
     assert res.status_code == 422
 
 

--- a/src/igvfd/tests/test_schema_phenotypic_feature.py
+++ b/src/igvfd/tests/test_schema_phenotypic_feature.py
@@ -8,7 +8,7 @@ def test_phenotypic_feature_required_lab_award(
     item = {
         'feature': phenotype_term_ncit_feature['@id']
     }
-    return testapp.post_json('/phenotypic_feature', item, expect_errors=True)
+    testapp.post_json('/phenotypic_feature', item, expect_errors=True)
     assert res.status_code == 422
 
 

--- a/src/igvfd/tests/test_views.py
+++ b/src/igvfd/tests/test_views.py
@@ -118,7 +118,7 @@ def test_collection_post(testapp, pi):
         'pi': pi['@id'],
         'status': 'current'
     }
-    return testapp.post_json('/lab', item, status=201)
+    testapp.post_json('/lab', item, status=201)
 
 
 def test_collection_post_bad_json(testapp):
@@ -231,11 +231,11 @@ def test_page_nested(workbook, anontestapp):
 
 
 def test_page_nested_in_progress(workbook, anontestapp):
-    return anontestapp.get('/test-section/subpage-in-progress/', status=403)
+    anontestapp.get('/test-section/subpage-in-progress/', status=403)
 
 
 def test_page_nested_preview_status(workbook, anontestapp):
-    return anontestapp.get('/test-section/subpage-preview-status/', status=200)
+    anontestapp.get('/test-section/subpage-preview-status/', status=200)
 
 
 def test_page_homepage(workbook, anontestapp, testapp):


### PR DESCRIPTION
Fix pytest warning e.g.:

```
src/igvfd/tests/test_views.py::test_page_nested_preview_status
igvfd-pyramid-1     |   /opt/venv/lib/python3.11/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but src/igvfd/tests/test_views.py::test_page_nested_preview_status returned <200 OK application/json body=b'{"lab": ...s/"}'/693>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
```