### PR TITLE
IGVF-2927-mouse-t2t-enum

### DIFF
--- a/src/igvfd/schemas/changelogs/gene.md
+++ b/src/igvfd/schemas/changelogs/gene.md
@@ -2,6 +2,8 @@
 
 ### Minor changes since schema version 10
 
+* Extend `locations.assembly` enum list to include `C57BL_6J_T2T_v1 + GRCm39_X`.
+* Extend `locations.assembly` enum list to include `CAST_EiJ_T2T_v1`.
 * Extend `collections` enum list to include `IGVF_catalog_v1.0`.
 * Extend `collections` enum list to include `Benchmark`.
 * Extend `collections` enum list to include `TF Perturb-seq Project`.

--- a/src/igvfd/schemas/changelogs/reference_file.md
+++ b/src/igvfd/schemas/changelogs/reference_file.md
@@ -2,6 +2,8 @@
 
 ### Minor changes since schema version 19
 
+* Extend `assembly` enum list to include `C57BL_6J_T2T_v1 + GRCm39_X`.
+* Extend `assembly` enum list to include `CAST_EiJ_T2T_v1`.
 * Extend `transcriptome_annotation` enum list to include `GENCODE 38`.
 * Add `catalog_collections`.
 * Extend `collections` enum list to include `IGVF_catalog_v1.0`.

--- a/src/igvfd/schemas/changelogs/tabular_file.md
+++ b/src/igvfd/schemas/changelogs/tabular_file.md
@@ -2,6 +2,8 @@
 
 ### Minor changes since schema version 18
 
+* Extend `assembly` enum list to include `C57BL_6J_T2T_v1 + GRCm39_X`.
+* Extend `assembly` enum list to include `CAST_EiJ_T2T_v1`.
 * Extend `transcriptome_annotation` enum list to include `GENCODE 38`.
 * Extend `content_type` enum list to include `spliceQTL`.
 * Extend `content_type` enum list to include `eQTL`.

--- a/src/igvfd/schemas/mixins.json
+++ b/src/igvfd/schemas/mixins.json
@@ -672,6 +672,8 @@
                 "GRCm39",
                 "mm10",
                 "GRCh38, mm10",
+                "C57BL_6J_T2T_v1 + GRCm39_X",
+                "CAST_EiJ_T2T_v1",
                 "custom"
             ],
             "submissionExample": {

--- a/src/igvfd/tests/data/inserts/reference_file.json
+++ b/src/igvfd/tests/data/inserts/reference_file.json
@@ -465,5 +465,30 @@
         ],
         "controlled_access": false,
         "external": false
+    },
+    {
+        "uuid": "3fcfafe0-eb3a-49a3-b245-e11ba8d30959",
+        "accession": "IGVFFI0010MTTT",
+        "lab": "j-michael-cherry",
+        "award": "HG012012",
+        "aliases": [
+            "igvf:reference_file_with_mouse_t2t_assembly"
+        ],
+        "status": "released",
+        "release_timestamp": "2024-03-06T12:34:56Z",
+        "md5sum": "25819105dd17d7eb1869d2c0aed3e156",
+        "file_format": "fasta",
+        "content_type": "genome reference",
+        "submitted_file_name": "/Users/igvf/igvf_files/genome_reference_mouse_t2t.fasta",
+        "file_size": 5898021,
+        "upload_status": "validated",
+        "assembly": "C57BL_6J_T2T_v1 + GRCm39_X",
+        "source_url": "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/964/188/535/GCA_964188535.1_C57BL_6J_T2T_v1/",
+        "file_set": "igvf:basic_analysis_set",
+        "dbxrefs": [
+            "ENSEMBL:ENSG00000101128"
+        ],
+        "controlled_access": false,
+        "external": false
     }
 ]


### PR DESCRIPTION
Note that I did not update the lists in the calculated properties for Alignment, Matrix, or Signal File because following the discussion during today's (Sep 12) wrangler meeting we will delete the enum lists in calculated properties for simplicity.