### PR TITLE
IGVF-3499-file-graph-embedding

### DIFF
--- a/src/igvfd/mappings/construct_library_set.json
+++ b/src/igvfd/mappings/construct_library_set.json
@@ -1,6 +1,6 @@
 {
-    "hash": "fb3c24640db6b5ea3f91ff0f1cb8f041",
-    "index_name": "construct_library_set_fb3c2464",
+    "hash": "24dcdfd02a725801997898bfb0cf92f4",
+    "index_name": "construct_library_set_24dcdfd0",
     "item_type": "construct_library_set",
     "mapping": {
         "dynamic_templates": [
@@ -328,7 +328,380 @@
                         "type": "keyword"
                     },
                     "control_file_sets": {
-                        "type": "keyword"
+                        "properties": {
+                            "@id": {
+                                "type": "keyword"
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "accession": {
+                                "type": "keyword"
+                            },
+                            "aliases": {
+                                "type": "keyword"
+                            },
+                            "alternate_accessions": {
+                                "type": "keyword"
+                            },
+                            "assay_slims": {
+                                "type": "keyword"
+                            },
+                            "assay_term": {
+                                "type": "keyword"
+                            },
+                            "assay_terms": {
+                                "type": "keyword"
+                            },
+                            "assay_titles": {
+                                "type": "keyword"
+                            },
+                            "assemblies": {
+                                "type": "keyword"
+                            },
+                            "assessed_genes": {
+                                "type": "keyword"
+                            },
+                            "associated_phenotypes": {
+                                "type": "keyword"
+                            },
+                            "auxiliary_sets": {
+                                "type": "keyword"
+                            },
+                            "average_guide_coverage": {
+                                "store": true,
+                                "type": "float"
+                            },
+                            "average_insert_size": {
+                                "store": true,
+                                "type": "float"
+                            },
+                            "award": {
+                                "type": "keyword"
+                            },
+                            "barcode_replacement_file": {
+                                "type": "keyword"
+                            },
+                            "cell_qualifier": {
+                                "type": "keyword"
+                            },
+                            "cell_type": {
+                                "type": "keyword"
+                            },
+                            "collections": {
+                                "type": "keyword"
+                            },
+                            "construct_library_sets": {
+                                "type": "keyword"
+                            },
+                            "control_file_sets": {
+                                "type": "keyword"
+                            },
+                            "control_for": {
+                                "type": "keyword"
+                            },
+                            "control_types": {
+                                "type": "keyword"
+                            },
+                            "controlled_access": {
+                                "store": true,
+                                "type": "boolean"
+                            },
+                            "creation_timestamp": {
+                                "type": "date"
+                            },
+                            "data_use_limitation_summaries": {
+                                "type": "keyword"
+                            },
+                            "dbxrefs": {
+                                "type": "keyword"
+                            },
+                            "demultiplexed_samples": {
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "type": "text"
+                            },
+                            "documents": {
+                                "type": "keyword"
+                            },
+                            "doi": {
+                                "type": "keyword"
+                            },
+                            "donors": {
+                                "type": "keyword"
+                            },
+                            "enrichment_designs": {
+                                "type": "keyword"
+                            },
+                            "exon": {
+                                "type": "keyword"
+                            },
+                            "external_image_data_url": {
+                                "type": "keyword"
+                            },
+                            "external_image_urls": {
+                                "type": "keyword"
+                            },
+                            "external_input_data": {
+                                "type": "keyword"
+                            },
+                            "externally_hosted": {
+                                "store": true,
+                                "type": "boolean"
+                            },
+                            "file_set_type": {
+                                "type": "keyword"
+                            },
+                            "file_sets": {
+                                "type": "keyword"
+                            },
+                            "files": {
+                                "type": "keyword"
+                            },
+                            "functional_assay_mechanisms": {
+                                "type": "keyword"
+                            },
+                            "guide_type": {
+                                "type": "keyword"
+                            },
+                            "hashtag_barcode_map": {
+                                "type": "keyword"
+                            },
+                            "input_file_sets": {
+                                "type": "keyword"
+                            },
+                            "input_for": {
+                                "type": "keyword"
+                            },
+                            "integrated_content_files": {
+                                "type": "keyword"
+                            },
+                            "is_on_anvil": {
+                                "store": true,
+                                "type": "boolean"
+                            },
+                            "lab": {
+                                "type": "keyword"
+                            },
+                            "large_scale_gene_list": {
+                                "type": "keyword"
+                            },
+                            "large_scale_loci_list": {
+                                "type": "keyword"
+                            },
+                            "library_preparation_kit": {
+                                "type": "keyword"
+                            },
+                            "lot_id": {
+                                "type": "keyword"
+                            },
+                            "lower_bound_guide_coverage": {
+                                "store": true,
+                                "type": "long"
+                            },
+                            "lower_bound_insert_size": {
+                                "store": true,
+                                "type": "long"
+                            },
+                            "measurement_sets": {
+                                "type": "keyword"
+                            },
+                            "model_name": {
+                                "type": "keyword"
+                            },
+                            "model_version": {
+                                "type": "keyword"
+                            },
+                            "model_zoo_location": {
+                                "type": "keyword"
+                            },
+                            "multiome_size": {
+                                "store": true,
+                                "type": "long"
+                            },
+                            "notes": {
+                                "type": "text"
+                            },
+                            "onlist_files": {
+                                "type": "keyword"
+                            },
+                            "onlist_method": {
+                                "type": "keyword"
+                            },
+                            "orf_list": {
+                                "type": "keyword"
+                            },
+                            "pipeline_parameters": {
+                                "type": "keyword"
+                            },
+                            "prediction_objects": {
+                                "type": "keyword"
+                            },
+                            "preferred_assay_slims": {
+                                "type": "keyword"
+                            },
+                            "preferred_assay_titles": {
+                                "type": "keyword"
+                            },
+                            "preview_timestamp": {
+                                "type": "date"
+                            },
+                            "product_id": {
+                                "type": "keyword"
+                            },
+                            "protocols": {
+                                "type": "keyword"
+                            },
+                            "publications": {
+                                "type": "keyword"
+                            },
+                            "related_measurement_sets": {
+                                "properties": {
+                                    "measurement_sets": {
+                                        "type": "keyword"
+                                    },
+                                    "series_type": {
+                                        "type": "keyword"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "release_timestamp": {
+                                "type": "date"
+                            },
+                            "revoke_detail": {
+                                "type": "keyword"
+                            },
+                            "sample_summary": {
+                                "type": "keyword"
+                            },
+                            "samples": {
+                                "type": "keyword"
+                            },
+                            "schema_version": {
+                                "type": "keyword"
+                            },
+                            "scope": {
+                                "type": "keyword"
+                            },
+                            "selection_criteria": {
+                                "type": "keyword"
+                            },
+                            "sequencing_library_types": {
+                                "type": "keyword"
+                            },
+                            "small_scale_gene_list": {
+                                "type": "keyword"
+                            },
+                            "small_scale_loci_list": {
+                                "properties": {
+                                    "assembly": {
+                                        "type": "keyword"
+                                    },
+                                    "chromosome": {
+                                        "type": "keyword"
+                                    },
+                                    "end": {
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "name": {
+                                        "type": "keyword"
+                                    },
+                                    "start": {
+                                        "store": true,
+                                        "type": "long"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "software_versions": {
+                                "type": "keyword"
+                            },
+                            "sources": {
+                                "type": "keyword"
+                            },
+                            "status": {
+                                "type": "keyword"
+                            },
+                            "strand_specificity": {
+                                "type": "keyword"
+                            },
+                            "submitted_by": {
+                                "type": "keyword"
+                            },
+                            "submitted_files_timestamp": {
+                                "type": "date"
+                            },
+                            "submitter_comment": {
+                                "type": "keyword"
+                            },
+                            "summary": {
+                                "type": "keyword"
+                            },
+                            "superseded_by": {
+                                "type": "keyword"
+                            },
+                            "supersedes": {
+                                "type": "keyword"
+                            },
+                            "targeted_genes": {
+                                "type": "keyword"
+                            },
+                            "targeted_proteins": {
+                                "type": "keyword"
+                            },
+                            "targeton": {
+                                "type": "keyword"
+                            },
+                            "taxa": {
+                                "type": "keyword"
+                            },
+                            "tile": {
+                                "properties": {
+                                    "tile_end": {
+                                        "store": true,
+                                        "type": "long"
+                                    },
+                                    "tile_id": {
+                                        "type": "keyword"
+                                    },
+                                    "tile_start": {
+                                        "store": true,
+                                        "type": "long"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "tiling_modality": {
+                                "type": "keyword"
+                            },
+                            "transcriptome_annotations": {
+                                "type": "keyword"
+                            },
+                            "uniform_pipeline_status": {
+                                "type": "keyword"
+                            },
+                            "upper_bound_guide_coverage": {
+                                "store": true,
+                                "type": "long"
+                            },
+                            "upper_bound_insert_size": {
+                                "store": true,
+                                "type": "long"
+                            },
+                            "url": {
+                                "type": "keyword"
+                            },
+                            "uuid": {
+                                "type": "keyword"
+                            },
+                            "workflows": {
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "object"
                     },
                     "control_for": {
                         "properties": {

--- a/src/igvfd/types/file_set.py
+++ b/src/igvfd/types/file_set.py
@@ -2240,6 +2240,7 @@ class ConstructLibrarySet(FileSet):
         Path('integrated_content_files', include=['@id', 'accession',
              'aliases', 'content_type', 'file_format', 'upload_status', 'status']),
         Path('control_for', include=['@id', 'accession', 'aliases', 'status']),
+        Path('control_file_sets', include=['@id', 'accession', 'aliases', 'status']),
         Path('associated_phenotypes', include=['@id', 'term_id', 'term_name', 'status']),
         Path('small_scale_gene_list', include=['@id', 'geneid', 'symbol', 'name', 'synonyms', 'allele', 'status']),
         Path('samples', include=['@id', '@type', 'accession',


### PR DESCRIPTION
Embed `control_file_sets` in construct library set objects just as they are in measurement set objects.